### PR TITLE
Import news in background

### DIFF
--- a/tvsharedb/lib/tasks/scheduler.rake
+++ b/tvsharedb/lib/tasks/scheduler.rake
@@ -26,3 +26,10 @@ task update_shows: :environment do
 
   puts "Finished updating existing shows."
 end
+
+desc "Import news"
+task import_news: :environment do
+  puts "Importing news..."
+  ImportNewsJob.perform_now
+  puts "Finished importing news."
+end


### PR DESCRIPTION
Creates a rake task to run the news importer. 

To run: `rake import_news`

This will be added to the Heroku Scheduler to run every X minutes.