### PR TITLE
Save TV episodes (not just series level)

### DIFF
--- a/tvsharedb/app/controllers/comments_controller.rb
+++ b/tvsharedb/app/controllers/comments_controller.rb
@@ -6,7 +6,14 @@ class CommentsController < ApplicationController
   # GET /comments
   def index
     if params[:tmsId]
-      @comments = Comment.includes(:show, :user).where(shows: { tmsId: params[:tmsId] })
+      if params[:tmsId].include?('SH')
+        # return comments for every episode for this show
+        show = get_show
+        @comments = Comment.includes(:show, :user).where(shows: { seriesId: show.seriesId })
+      else
+        @comments = Comment.includes(:show, :user).where(shows: { tmsId: params[:tmsId] })
+      end
+
       @current_user_liked_ids = get_current_user_liked_comments(@comments)
       @current_user_reply_comment_ids = get_current_user_reply_comments(@comments)
     end

--- a/tvsharedb/app/controllers/shows/episodes_controller.rb
+++ b/tvsharedb/app/controllers/shows/episodes_controller.rb
@@ -1,0 +1,24 @@
+class Shows::EpisodesController < ActionController::Base
+  
+  def index
+    @show = get_show
+    @episodes_by_season = Show.where(seriesId: @show.seriesId).where.not(seasonNum: nil, episodeNum: nil).reduce({}) do |memo, show|
+      memo[show.seasonNum] ||= []
+      memo[show.seasonNum].push(show)
+      memo[show.seasonNum].sort_by { |show| show.episodeNum }
+      memo
+    end
+  end
+
+  private
+
+  def get_show
+    show = Show.find_by(tmsId: params[:id])
+    if show.blank?
+      ImportShowJob.perform_now(tmsId: params[:id])
+      show = Show.find_by(tmsId: params[:id])
+    end
+    show
+  end
+
+end

--- a/tvsharedb/app/jobs/import_show_job.rb
+++ b/tvsharedb/app/jobs/import_show_job.rb
@@ -11,6 +11,11 @@ class ImportShowJob < ApplicationJob
   def perform(options)
     program = HTTParty.get api_url(options)
     import_show(program)
+
+    # import a show's episodes
+    if program['seriesId'].present?
+      import_episodes(program['seriesId'])
+    end
   end
 
   def import_show(program)
@@ -20,6 +25,9 @@ class ImportShowJob < ApplicationJob
       seriesId: program['seriesId'],
       subType: program['subType'],
       title: program['title'],
+      episodeTitle: program['episodeTitle'],
+      episodeNum: program['episodeNum'],
+      seasonNum: program['seasonNum'],
       releaseYear: program['releaseYear'],
       releaseDate: program['releaseDate'],
       origAirDate: program['origAirDate'],
@@ -34,6 +42,27 @@ class ImportShowJob < ApplicationJob
       updated_at: Time.now, # record an attempt to update even if data isn't changed
     })
   end
+
+  def import_episodes(series_id, offset = 0)
+    page_response = HTTParty.get("https://data.tmsapi.com/v1.1/series/#{series_id}/episodes?api_key=#{ENV['TMS_API_KEY']}&offset=#{offset}")
+
+    if page_response['errorCode']
+      return # no more episodes
+    end
+
+    max_offset = page_response['hitCount']
+
+    page_response['hits'].each do |episode|
+      import_show(episode)
+      offset += 1
+    end
+
+    unless offset >= max_offset
+      import_episodes(series_id, offset)
+    end
+  end
+
+  private
 
   def api_url(options)
     if options[:tmsId]

--- a/tvsharedb/app/models/comment.rb
+++ b/tvsharedb/app/models/comment.rb
@@ -1,6 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
-  belongs_to :show
+  belongs_to :show, counter_cache: true
   has_many :likes, dependent: :destroy
   has_many :sub_comments, dependent: :destroy
   has_many :shares, as: :shareable

--- a/tvsharedb/app/models/like.rb
+++ b/tvsharedb/app/models/like.rb
@@ -1,7 +1,7 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :comment, optional: true, counter_cache: true
-  belongs_to :show, optional: true
+  belongs_to :show, optional: true, counter_cache: true
   belongs_to :sub_comment, optional: true
   belongs_to :story, optional: true, counter_cache: true
 

--- a/tvsharedb/app/models/show.rb
+++ b/tvsharedb/app/models/show.rb
@@ -32,11 +32,23 @@ class Show < ApplicationRecord
   scope :with_tms_id, -> { where.not(tmsId: nil) }
   scope :without_tms_id, -> { where(tmsId: nil) }
   scope :non_episode, -> { where.not("\"tmsId\" like 'EP%'") }
+  scope :exclude_episodes, -> { where(Show.arel_table[:seriesId].matches Show.arel_table[:rootId]) }
 
   # Checks only the first element in the genre array.
   # Quick solution to prevent duplicates across genres.
   scope :by_genre, -> (genre) { where("genres[1] = ?", genre.titlecase) }
   scope :by_genres, -> (genres) { where("genres[1] IN (?)", genres.map(&:titlecase)) }
+
+
+  def season_and_episode_number
+    if episodeNum && seasonNum
+      "S#{seasonNum}:E#{episodeNum}"
+    end
+  end
+
+  def activity_count
+    [shares_count, likes_count, comments_count, stories_count].inject(:+) || 0
+  end
 
   # This is used when querying the news-search API
   def news_query

--- a/tvsharedb/app/models/story.rb
+++ b/tvsharedb/app/models/story.rb
@@ -1,6 +1,6 @@
 # AKA "News"
 class Story < ApplicationRecord
-  belongs_to :show, optional: true
+  belongs_to :show, optional: true, counter_cache: true
   has_many :likes
   has_many :shares, as: :shareable
 end

--- a/tvsharedb/app/views/shows/episodes/index.jbuilder
+++ b/tvsharedb/app/views/shows/episodes/index.jbuilder
@@ -1,0 +1,18 @@
+episode_data = []
+@episodes_by_season.each do |season, episodes|
+  episodes.each do |episode|
+    episode_data.push({
+      season_number: episode.seasonNum,
+      episode_number: episode.episodeNum,
+      tmsId: episode.tmsId,
+      formatted_episode_number: episode.season_and_episode_number,
+      shares_count: episode.shares_count,
+      likes_count: episode.likes_count,
+      comments_count: episode.comments_count,
+      stories_count: episode.stories_count,
+      activity_count: episode.activity_count
+      })
+  end
+end
+
+json.episodes episode_data.sort_by { |e| [e[:season_number], e[:episode_number]] }

--- a/tvsharedb/config/routes.rb
+++ b/tvsharedb/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
     member do
       get 'news', to: 'shows/news#index'
     end
+    member do
+      get 'episodes', to: 'shows/episodes#index'
+    end
   end
   resources :likes
   resources :comments

--- a/tvsharedb/db/migrate/20200927191814_add_episode_fields_to_shows.rb
+++ b/tvsharedb/db/migrate/20200927191814_add_episode_fields_to_shows.rb
@@ -1,0 +1,7 @@
+class AddEpisodeFieldsToShows < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shows, :episodeTitle, :string
+    add_column :shows, :episodeNum, :integer
+    add_column :shows, :seasonNum, :integer
+  end
+end

--- a/tvsharedb/db/migrate/20200927205000_add_likes_and_comments_count_on_shows.rb
+++ b/tvsharedb/db/migrate/20200927205000_add_likes_and_comments_count_on_shows.rb
@@ -1,0 +1,11 @@
+class AddLikesAndCommentsCountOnShows < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shows, :comments_count, :bigint, default: 0
+    add_column :shows, :likes_count, :bigint, default: 0
+    add_column :shows, :stories_count, :bigint, default: 0
+
+    Show.find_each do |show|
+      Show.reset_counters(show.id, :comments, :likes, :shares, :stories)
+    end
+  end
+end

--- a/tvsharedb/db/schema.rb
+++ b/tvsharedb/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_19_002806) do
+ActiveRecord::Schema.define(version: 2020_09_27_205000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,6 +191,12 @@ ActiveRecord::Schema.define(version: 2020_09_19_002806) do
     t.string "original_streaming_network_id"
     t.string "preferred_image_uri"
     t.bigint "shares_count", default: 0
+    t.string "episodeTitle"
+    t.integer "episodeNum"
+    t.integer "seasonNum"
+    t.bigint "comments_count", default: 0
+    t.bigint "likes_count", default: 0
+    t.bigint "stories_count", default: 0
     t.index ["original_streaming_network", "original_streaming_network_id"], name: "orignal_network_and_id", unique: true
     t.index ["original_streaming_network"], name: "index_shows_on_original_streaming_network"
     t.index ["tmsId"], name: "index_shows_on_tmsId", unique: true

--- a/tvsharedb/test/jobs/import_show_job_test.rb
+++ b/tvsharedb/test/jobs/import_show_job_test.rb
@@ -2,15 +2,14 @@ require 'test_helper'
 
 class ImportShowJobTest < ActiveJob::TestCase
   setup do
+    @movie_tms_id = 'MV003358300000'
     @tms_id = 'SH006883590000'
     @series_id = '185044'
   end
 
   test 'show is imported via TMS ID and Gracenote API' do
-    @tms_id = 'SH006883590000'
-
     VCR.use_cassette(@tms_id) do
-      assert_difference('Show.count', 1) do
+      assert_difference('Show.count', 268) do
         ImportShowJob.perform_now(tmsId: @tms_id)
       end
     end
@@ -29,9 +28,9 @@ class ImportShowJobTest < ActiveJob::TestCase
     assert_equal 'http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg', show.preferred_image_uri
   end
 
-  test 'show is imported via Series ID and Gracenote API' do
+  test 'show and episodes are imported via Series ID and Gracenote API' do
     VCR.use_cassette("series_#{@series_id}") do
-      assert_difference('Show.count', 1) do
+      assert_difference('Show.count', 268) do
         ImportShowJob.perform_now(seriesId: @series_id)
       end
     end
@@ -48,5 +47,26 @@ class ImportShowJobTest < ActiveJob::TestCase
     assert_equal 'en', show.titleLang
     assert_equal ['Drama', 'Mystery', 'Medical'], show.genres
     assert_equal 'http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg', show.preferred_image_uri
+  end
+
+  test 'movies are imported via TMS ID API' do
+    VCR.use_cassette("tms_id#{@movie_tms_id}") do
+      assert_difference('Show.count', 1) do
+        ImportShowJob.perform_now(tmsId: @movie_tms_id)
+      end
+    end
+
+    show = Show.find_by(tmsId: @movie_tms_id)
+    assert_equal 'Big Mommas: Like Father, Like Son', show.title
+    assert_equal 'Movie', show.entityType
+    assert_equal nil, show.origAirDate
+    assert_equal '2011-02-18', show.releaseDate.to_s
+    assert_equal 2011, show.releaseYear
+    assert_equal '8329393', show.rootId
+    assert_equal nil, show.seriesId
+    assert_equal 'Feature Film', show.subType
+    assert_equal 'en', show.titleLang
+    assert_equal ['Comedy'], show.genres
+    assert_equal 'http://wewe.tmsimg.com/assets/p8329393_v_v5_ab.jpg', show.preferred_image_uri
   end
 end

--- a/tvsharedb/test/vcr_cassettes/SH006883590000.yml
+++ b/tvsharedb/test/vcr_cassettes/SH006883590000.yml
@@ -19,19 +19,19 @@ http_interactions:
       message: OK
     headers:
       Cache-Control:
-      - max-age=7200
+      - max-age=7158
       Content-Type:
-      - application/json;charset=UTF-8
+      - application/json;charset=utf-8
       Date:
-      - Thu, 16 Jul 2020 16:41:16 GMT
+      - Sun, 27 Sep 2020 20:10:31 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding,Origin
       X-Mashery-Responder:
-      - prod-j-worker-us-west-1c-17.mashery.com
+      - prod-j-worker-us-west-1b-26.mashery.com
       Content-Length:
-      - '2380'
+      - '2388'
       Connection:
       - keep-alive
     body:
@@ -97,7 +97,19 @@ http_interactions:
         Drama Series","awardCatId":"60"},{"awardId":"2","name":"Golden Globe","awardName":"Golden
         Globe","year":"2009","category":"Best Television Series - Drama","awardCatId":"111"},{"awardId":"2","recipient":"Hugh
         Laurie","name":"Golden Globe","awardName":"Golden Globe","personId":"87269","year":"2009","category":"Best
-        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Peter
+        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Robert
+        Sean Leonard","name":"Screen Actors Guild Awards","awardName":"Screen Actors
+        Guild Awards","personId":"55541","year":"2009","category":"Outstanding Performance
+        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Omar
+        Epps","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
+        Awards","personId":"72370","year":"2009","category":"Outstanding Performance
+        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Hugh
+        Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
+        Awards","personId":"87269","year":"2009","category":"Outstanding Performance
+        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Hugh
+        Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
+        Awards","personId":"87269","won":"true","year":"2009","category":"Outstanding
+        Performance by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"3","recipient":"Peter
         Jacobson","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
         Awards","personId":"168500","year":"2009","category":"Outstanding Performance
         by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Jesse
@@ -115,19 +127,7 @@ http_interactions:
         by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Lisa
         Edelstein","name":"Screen Actors Guild Awards","awardName":"Screen Actors
         Guild Awards","personId":"68332","year":"2009","category":"Outstanding Performance
-        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Robert
-        Sean Leonard","name":"Screen Actors Guild Awards","awardName":"Screen Actors
-        Guild Awards","personId":"55541","year":"2009","category":"Outstanding Performance
-        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Omar
-        Epps","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
-        Awards","personId":"72370","year":"2009","category":"Outstanding Performance
-        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Hugh
-        Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
-        Awards","personId":"87269","year":"2009","category":"Outstanding Performance
-        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Hugh
-        Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
-        Awards","personId":"87269","won":"true","year":"2009","category":"Outstanding
-        Performance by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","name":"Emmy
+        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"4","name":"Emmy
         (Primetime)","awardName":"Emmy (Primetime)","year":"2009","category":"Outstanding
         Drama Series","awardCatId":"60"},{"awardId":"4","recipient":"Hugh Laurie","name":"Emmy
         (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2009","category":"Outstanding
@@ -157,7 +157,2303 @@ http_interactions:
         Rating","code":"PG"},{"body":"Australian Classification Board","code":"MA
         15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Direcci\u00f3n
         General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B15"}],"recommendations":[{"tmsId":"SH007322830000","rootId":"185019","title":"Grey''s
-        Anatomy"},{"tmsId":"SH026966280000","rootId":"14159582","title":"The Good
-        Doctor"},{"tmsId":"SH021835930000","rootId":"11770123","title":"Chicago Med"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}'
-  recorded_at: Thu, 16 Jul 2020 16:41:16 GMT
+        Anatomy"},{"tmsId":"SH021835930000","rootId":"11770123","title":"Chicago Med"},{"tmsId":"SH026966280000","rootId":"14159582","title":"The
+        Good Doctor"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}'
+  recorded_at: Sun, 27 Sep 2020 20:11:13 GMT
+- request:
+    method: get
+    uri: https://data.tmsapi.com/v1.1/series/185044/episodes?api_key=<TMS_API_KEY>&offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7158
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:10:31 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1b-04.mashery.com
+      Content-Length:
+      - '11013'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hitCount":267,"hits" :  [{"tmsId":"EP006883590215","rootId":"7838667","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590140","rootId":"3344958","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590219","rootId":"7889825","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590216","rootId":"7850276","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590214","rootId":"3550270","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590210","rootId":"3345028","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590269","rootId":"9201256","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590209","rootId":"3345027","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590213","rootId":"3537900","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590211","rootId":"3345029","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590208","rootId":"3345026","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590212","rootId":"3496354","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590124","rootId":"7899195","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590217","rootId":"7856765","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590218","rootId":"7870319","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590138","rootId":"3344956","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590222","rootId":"8216637","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590001","rootId":"3056194","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Pilot","releaseYear":2004,"releaseDate":"2004-11-16","origAirDate":"2004-11-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House (Hugh Laurie) and his team try to save the life of a kindergarten teacher
+        (Robin Tunney) who began speaking gibberish and passed out in front of her
+        students.","shortDescription":"Dr. House and his team try to save the life
+        of a kindergarten teacher.","episodeNum":1,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Bryan Singer"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590003","rootId":"3056196","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Paternity","releaseYear":2004,"releaseDate":"2004-11-23","origAirDate":"2004-11-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House and the team think a teenage lacrosse player has multiple sclerosis
+        until the boy''s night-terrors disprove their diagnosis.","shortDescription":"Dr.
+        House and the team think a teenage lacrosse player has multiple sclerosis.","episodeNum":2,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590002","rootId":"3056195","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Occam''s
+        Razor","releaseYear":2004,"releaseDate":"2004-04-30","origAirDate":"2004-11-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        collegian collapses after raucous sex with his girlfriend, and Dr. House and
+        his team scramble to figure out why as the student''s condition worsens.","shortDescription":"A
+        collegian collapses, and House and his team scramble to figure out why.","episodeNum":3,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Bryan Singer"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590005","rootId":"3056198","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Maternity","releaseYear":2004,"releaseDate":"2004-12-07","origAirDate":"2004-12-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House annoys his boss when he suggests that two sick newborns in the hospital
+        are the start of an epidemic, but as more babies fall ill, the maternity ward
+        closes and the doctors battle over courses of treatment.","shortDescription":"Dr.
+        House annoys his boss when he suggests that two sick newborns in the hospital
+        begin an epidemic.","episodeNum":4,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Newton Thomas Sigel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590006","rootId":"3056199","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Damned
+        if You Do","releaseYear":2004,"releaseDate":"2004-12-14","origAirDate":"2004-12-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House''s approach raises questions when he treats a nun for what he believes
+        to be an allergy, not realizing that her past is coming back to haunt her.","shortDescription":"Dr.
+        House''s approach raises questions when he treats a nun for what he believes
+        is an allergy.","episodeNum":5,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590007","rootId":"3056200","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Socratic Method","releaseYear":2004,"releaseDate":"2004-12-21","origAirDate":"2004-12-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House shows special interest in a schizophrenic with deep-vein thrombosis
+        and her teenage son, who is her primary caregiver.","shortDescription":"Dr.
+        House shows special interest in a schizophrenic with deep-vein thrombosis
+        and her teenage son.","episodeNum":6,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Peter Medak"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590004","rootId":"3056197","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fidelity","releaseYear":2004,"releaseDate":"2004-12-28","origAirDate":"2004-12-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a young housewife falls ill, House suspects that she has contracted a rare
+        sexually transmitted disease, but she and her husband (Dominic Purcell) each
+        deny having an affair.","shortDescription":"House suspects a rare sexually
+        transmitted disease when a housewife falls ill.","episodeNum":7,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Bryan Spicer"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590008","rootId":"3056201","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Poison","releaseYear":2005,"releaseDate":"2005-01-25","origAirDate":"2005-01-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team investigate the mysterious poisoning of a high-school student,
+        and they think they have the answers they need until a second teen develops
+        the same symptoms.","shortDescription":"House and his team investigate the
+        mysterious poisoning of a high-school student.","episodeNum":8,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Guy Ferland"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590010","rootId":"3056203","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"DNR","releaseYear":2005,"releaseDate":"2005-02-01","origAirDate":"2005-02-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        legendary jazz musician checks into the hospital, believing he is dying of
+        ALS, and signs a \"do not resuscitate\" order, but House disagrees with the
+        diagnosis and violates the order to save the man''s life, landing himself
+        in court.","shortDescription":"House violates the DNR order of a legendary
+        musician and saves his life.","episodeNum":9,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Frederick K.
+        Keller"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590275","rootId":"3056203","seriesId":"185044","subType":"Series","title":"House","releaseYear":2005,"releaseDate":"2005-02-01","origAirDate":"2005-02-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        legendary jazz musician checks into the hospital, believing he is dying of
+        ALS, and signs a \"do not resuscitate\" order, but House disagrees with the
+        diagnosis and violates the order to save the man''s life, landing himself
+        in court.","shortDescription":"House violates the DNR order of a legendary
+        musician and saves his life.","episodeNum":9,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Frederick K.
+        Keller"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590011","rootId":"3056204","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Histories","releaseYear":2005,"releaseDate":"2005-02-08","origAirDate":"2005-02-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        Foreman believes an uncooperative homeless woman is faking seizures so she
+        can stay in the hospital, but her worsening symptoms prove to be a complex
+        mystery for Dr. House and his team.","shortDescription":"Dr. Foreman believes
+        an uncooperative homeless woman is faking seizures.","episodeNum":10,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Daniel Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590013","rootId":"3056205","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Detox","releaseYear":2005,"releaseDate":"2005-02-15","origAirDate":"2005-02-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        agrees to stop taking painkillers for a week in exchange for a month without
+        clinic duty, but the team thinks detox is affecting his judgment in the case
+        of a young man''s unexplained blood loss.","shortDescription":"House agrees
+        to stop taking painkillers for a week in exchange for a month without clinic
+        duty.","episodeNum":11,"seasonNum":1,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Nelson McCormick"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590009","rootId":"3056202","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Sports
+        Medicine","releaseYear":2005,"releaseDate":"2005-02-22","origAirDate":"2005-02-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        severely broken arm reveals underlying problems and ends the comeback plans
+        of a major league pitcher (Scott Foley), whom House suspects is taking steroids.","shortDescription":"A
+        severely broken arm reveals underlying problems for a major league pitcher.","episodeNum":12,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Keith Gordon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590014","rootId":"3056206","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Cursed","releaseYear":2005,"releaseDate":"2005-03-01","origAirDate":"2005-03-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a financial supporter of the hospital gets a divorce, his son falls ill and
+        begins to believe he is cursed, leaving House and the team trying to treat
+        him and deal with his demanding father.","shortDescription":"The team tries
+        to treat the son of a demanding financial supporter of the hospital.","episodeNum":13,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590015","rootId":"3056207","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Control","releaseYear":2005,"releaseDate":"2005-03-08","origAirDate":"2005-03-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Billionaire
+        entrepreneur Edward Vogler (Chi McBride) buys his way into becoming chairman
+        of the board with plans to use the facility as a new biotech venture, which
+        could mean the hospital no longer needs the services of Dr. House.","shortDescription":"Billionaire
+        entrepreneur Edward Vogler buys his way into becoming chairman of the board.","episodeNum":14,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Randy Zisk"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590016","rootId":"3056208","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Mob
+        Rules","releaseYear":2005,"releaseDate":"2005-03-22","origAirDate":"2005-03-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a mob informant suddenly collapses before court, House and his team try to
+        cure him or determine whether he is faking.","shortDescription":"When a mob
+        informant suddenly collapses before court, House is called upon to cure him.","episodeNum":15,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tim Hunter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590017","rootId":"3056209","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Heavy","releaseYear":2005,"releaseDate":"2005-03-29","origAirDate":"2005-03-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team blame an adverse reaction to diet pills after an obese 10-year-old
+        girl has a heart attack but, ultimately, they find another cause for her illness.","shortDescription":"House
+        and his team blame a reaction to diet pills after an obese girl has a heart
+        attack.","episodeNum":16,"seasonNum":1,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Fred Gerber"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590018","rootId":"3056210","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Role
+        Model","releaseYear":2005,"releaseDate":"2005-04-12","origAirDate":"2005-04-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        Tom Wright, a senator with presidential aspirations, becomes ill, House examines
+        him and finds that the symptoms point toward AIDS, a condition that would
+        squash his career.","shortDescription":"When Sen. Tom Wright becomes ill,
+        House examines him and finds that the symptoms point toward AIDS.","episodeNum":17,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590019","rootId":"3056211","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Babies
+        & Bathwater","releaseYear":2005,"releaseDate":"2005-04-19","origAirDate":"2005-04-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team scramble to find the cause of kidney and brain dysfunction in
+        a pregnant patient, leaving the woman and her husband to face a heartbreaking
+        choice, and Vogler continues his quest to have House fired.","shortDescription":"House
+        and his team scramble to find the cause of kidney and brain dysfunction in
+        a pregnant patient.","episodeNum":18,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Bill Johnson"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590022","rootId":"3056214","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Kids","releaseYear":2005,"releaseDate":"2005-05-03","origAirDate":"2005-05-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        meningitis scare overwhelms the resources and staff of the hospital, but House
+        singles out a 12-year-old patient whose symptoms are similar to but not quite
+        right for the disease.","shortDescription":"A meningitis scare overwhelms
+        the resources and staff of the hospital.","episodeNum":19,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590023","rootId":"3056215","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Love
+        Hurts","releaseYear":2005,"releaseDate":"2005-05-10","origAirDate":"2005-05-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and Cameron explore their relationship; the team tries to discover what is
+        causing a young man to have blood clots and strokes.","shortDescription":"The
+        team tries to discover what is causing a young man to have blood clots and
+        strokes.","episodeNum":20,"seasonNum":1,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Bryan Spicer"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590020","rootId":"3056212","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Three
+        Stories","releaseYear":2005,"releaseDate":"2005-05-17","origAirDate":"2005-05-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        woman from Dr. House''s past returns to the hospital, where she used to be
+        legal counsel, seeking his help in diagnosing the illness her husband has.","shortDescription":"A
+        woman from Dr. House''s past returns for his help in a diagnosis.","episodeNum":21,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Paris Barclay"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590021","rootId":"3056213","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Honeymoon","releaseYear":2005,"releaseDate":"2005-05-24","origAirDate":"2005-05-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        House works to save Stacy''s husband, he cannot help but think his feelings
+        for her may have reignited.","shortDescription":"While House works to save
+        Stacy''s husband, he must deal with his feelings for her.","episodeNum":22,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Frederick King
+        Keller"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590024","rootId":"3056216","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Acceptance","releaseYear":2005,"releaseDate":"2005-09-13","origAirDate":"2005-09-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        death row inmate Clarence mysteriously collapses after hallucinating, House
+        jumps at the case for its difficulty and because he thinks it is \"cool.\"","shortDescription":"A
+        death row inmate mysteriously collapses after hallucinating.","episodeNum":1,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590025","rootId":"3056217","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Autopsy","releaseYear":2005,"releaseDate":"2005-09-20","origAirDate":"2005-09-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        9-year-old patient with terminal cancer handles her situation so well that
+        House begins to wonder whether she is really that brave or if it is a medical
+        symptom.","shortDescription":"A child with terminal cancer copes so well that
+        House questions why.","episodeNum":2,"seasonNum":2,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590026","rootId":"3056218","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Humpty
+        Dumpty","releaseYear":2005,"releaseDate":"2005-09-27","origAirDate":"2005-09-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        Cuddy''s handyman, Alfredo, falls from her roof and develops strange symptoms,
+        she joins the team to figure out what is wrong with him.","shortDescription":"Cuddy''s
+        handyman falls from her roof and develops strange symptoms.","episodeNum":3,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590027","rootId":"3056219","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"TB
+        or Not TB","releaseYear":2005,"releaseDate":"2005-11-01","origAirDate":"2005-11-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        hospital admits a renowned physician and advocate against the spread of tuberculosis
+        in Africa, and his TB-like symptoms draw media attention which could further
+        his cause.","shortDescription":"The hospital admits a renowned physician and
+        advocate against the spread of tuberculosis in Africa.","episodeNum":4,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590028","rootId":"3056220","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Daddy''s
+        Boy","releaseYear":2005,"releaseDate":"2005-11-08","origAirDate":"2005-11-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Trust
+        issues between a father and his mysteriously ill son prevent the medical team
+        from getting the information they need to diagnose and treat the illness.","shortDescription":"Trust
+        issues between a father and his mysteriously ill son hinder a diagnosis.","episodeNum":5,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590029","rootId":"3056221","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Spin","releaseYear":2005,"releaseDate":"2005-11-15","origAirDate":"2005-11-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        resists treating a famous bicyclist, brought in after collapsing during a
+        race, because he believes the athlete is taking performance enhancers.","shortDescription":"House
+        resists treating a famous bicyclist he believes is taking performance enhancers.","episodeNum":6,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Fred Gerber"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590030","rootId":"3056222","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Hunting","releaseYear":2005,"releaseDate":"2005-11-22","origAirDate":"2005-11-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        searches for connections between the unique symptoms exhibited by a gay AIDS
+        patient and his father.","shortDescription":"House treats unique symptoms
+        exhibited by a gay AIDS patient and his father.","episodeNum":7,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Gloria Muzio"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVMA"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"18+"},{"body":"R\u00e9gie du cin\u00e9ma","code":"18+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590031","rootId":"3056223","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Mistake","releaseYear":2005,"releaseDate":"2005-11-29","origAirDate":"2005-11-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young mother with stomach pain dies, and Stacy (Sela Ward) must determine
+        whether Chase made a mistake that caused her death.","shortDescription":"Stacy
+        determines whether Chase made a mistake that caused a death.","episodeNum":8,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Semel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590032","rootId":"3056224","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Deception","releaseYear":2005,"releaseDate":"2005-12-13","origAirDate":"2005-12-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Off-track
+        betting gambler Anica (Cynthia Nixon) collapses in front of House while they
+        are both following horse races at the site.","shortDescription":"A gambler
+        collapses in front of House while they are both following horse races at the
+        site.","episodeNum":9,"seasonNum":2,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590033","rootId":"3056225","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Failure
+        to Communicate","releaseYear":2006,"releaseDate":"2006-01-10","origAirDate":"2006-01-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"With
+        House and Stacy out of town, the team is left on its own to help a journalist,
+        whose sudden collapse is followed by an inability to speak clearly.","shortDescription":"On
+        its own, the team must help a journalist who suddenly collapses.","episodeNum":10,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Jace Alexander"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590034","rootId":"3056226","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Need
+        to Know","releaseYear":2006,"releaseDate":"2006-02-07","origAirDate":"2006-02-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        housewife (Julie Warner) on fertility medication visits Princeton Plainsboro
+        Hospital when her inexplicable muscle-flailing causes her to crash her car.","shortDescription":"Woman''s
+        inexplicable muscle-flailing causes her to crash a car.","episodeNum":11,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Semel","Pamela Davis"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590035","rootId":"3056227","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Distractions","releaseYear":2006,"releaseDate":"2006-02-14","origAirDate":"2006-02-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a young man comes into the hospital severely burned and has unusual blood-test
+        results, House and his team have a difficult challenge.","shortDescription":"A
+        young man comes into the hospital severely burned and has unusual blood-test
+        results.","episodeNum":12,"seasonNum":2,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Dan Attias"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590036","rootId":"3056228","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Skin
+        Deep","releaseYear":2006,"releaseDate":"2006-02-20","origAirDate":"2006-02-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a supermodel for heroin addiction, Dr. House uncovers a startling
+        secret; Wilson hopes that House''s increased leg pain is proof that his nerves
+        are regenerating.","shortDescription":"While treating a supermodel for heroin
+        addiction, Dr. House uncovers a startling secret.","episodeNum":13,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["James Hayman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590037","rootId":"3056229","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Sex
+        Kills","releaseYear":2006,"releaseDate":"2006-03-07","origAirDate":"2006-03-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        believes a patient''s (Howard Hesseman) seizure was caused by an infection,
+        but the man''s sudden heart attack forces the team to change direction and
+        opt for a heart transplant.","shortDescription":"A seizure patient''s heart
+        attack prompts the team to consider a transplant.","episodeNum":14,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Semel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590038","rootId":"3056230","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Clueless","releaseYear":2006,"releaseDate":"2006-03-28","origAirDate":"2006-03-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man suffers from a breathing attack while role-playing in the bedroom with
+        his wife.","shortDescription":"A man suffers from a breathing attack while
+        role-playing in the bedroom with his wife.","episodeNum":15,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590039","rootId":"3056231","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Safe","releaseYear":2006,"releaseDate":"2006-04-04","origAirDate":"2006-04-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young heart-transplant patient has a severe allergic reaction and goes into
+        shock despite living in a \"clean\" room.","shortDescription":"A patient has
+        a severe allergic reaction despite living in a \"clean\" room.","episodeNum":16,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Felix Alcala"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590040","rootId":"3056232","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"All
+        In","releaseYear":2006,"releaseDate":"2006-04-11","origAirDate":"2006-04-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        tries to save the life of a young boy who has the same unique symptoms as
+        an elderly patient who died.","shortDescription":"A young boy who has the
+        same unique symptoms as a patient who died.","episodeNum":17,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Fred Gerber"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590041","rootId":"3056233","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Sleeping
+        Dogs Lie","releaseYear":2006,"releaseDate":"2006-04-18","origAirDate":"2006-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        relationship between a liver donor and the intended recipient throws the team
+        into an ethical quandary.","shortDescription":"A donor-recipient relationship
+        throws the team into an ethical quandary.","episodeNum":18,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590042","rootId":"3056234","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House
+        vs. God","releaseYear":2006,"releaseDate":"2006-04-25","origAirDate":"2006-04-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        takes on a teenage faith healer; tension brews between Cameron and Foreman.","shortDescription":"House
+        takes on a teenage faith healer; tension brews between Cameron and Foreman.","episodeNum":19,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["John F. Showalter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590043","rootId":"3056235","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Euphoria,
+        Part 1","releaseYear":2006,"releaseDate":"2006-05-02","origAirDate":"2006-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":1,"totalParts":2},"longDescription":"A
+        police officer in critical condition has bizarre symptoms; Dr. Foreman finds
+        himself in an unpleasant situation.","shortDescription":"A cop in critical
+        condition has odd symptoms; Dr. Foreman finds himself in an unpleasant situation.","episodeNum":20,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590044","rootId":"3056236","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Euphoria,
+        Part 2","releaseYear":2006,"releaseDate":"2006-05-02","origAirDate":"2006-05-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":2,"totalParts":2},"longDescription":"Facing
+        imminent death, Dr. Foreman talks with his father and tries to make amends;
+        House tries radical procedures to save Foreman''s life.","shortDescription":"Facing
+        imminent death, Dr. Foreman talks with his father and tries to make amends.","episodeNum":21,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590045","rootId":"3056237","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Forever","releaseYear":2006,"releaseDate":"2006-05-09","origAirDate":"2006-05-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team try to save the lives of a young mother and her newborn son;
+        Foreman struggles to regain normalcy in his life.","shortDescription":"House
+        and the team try to save the lives of a young mother and her newborn son.","episodeNum":22,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590046","rootId":"3056238","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Who''s
+        Your Daddy?","releaseYear":2006,"releaseDate":"2006-05-16","origAirDate":"2006-05-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House''s
+        former bandmate, Crandall, brings in a teenage girl who is having hallucinations
+        about Hurricane Katrina; Cuddy looks for a sperm donor.","shortDescription":"House''s
+        former bandmate brings in a hallucinating girl; Cuddy looks for a sperm donor.","episodeNum":23,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Martha Mitchell"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590047","rootId":"3056239","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"No
+        Reason","releaseYear":2006,"releaseDate":"2006-05-23","origAirDate":"2006-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        disgruntled former patient (Elias Koteas) walks into House''s office and shoots
+        him while House and his team are trying to help a man with a swollen tongue.","shortDescription":"A
+        disgruntled former patient walks into House''s office and shoots him.","episodeNum":24,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Shore"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590048","rootId":"3056240","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Meaning","releaseYear":2006,"releaseDate":"2006-09-05","origAirDate":"2006-09-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        returns to work after healing from gunshot wounds; a paraplegic man drives
+        into a swimming pool; a young woman finds herself paralyzed after a yoga session.","shortDescription":"House
+        returns to work after healing from gunshot wounds to two cases involving paralysis.","episodeNum":1,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590049","rootId":"3056241","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Cane
+        & Able","releaseYear":2006,"releaseDate":"2006-09-12","origAirDate":"2006-09-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        denies his physical pain; a child comes to the hospital with rectal bleeding
+        and proclamations of being tortured by aliens.","shortDescription":"House
+        denies his physical pain; a child has claims of being tortured by aliens.","episodeNum":2,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590050","rootId":"3056242","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Informed
+        Consent","releaseYear":2006,"releaseDate":"2006-09-17","origAirDate":"2006-09-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and team wrestle with an ethical dilemma when a patient asks them to help
+        him end his life.","shortDescription":"House and team wrestle with an ethical
+        dilemma when a patient asks them to help him end his life.","episodeNum":3,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Laura Innes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590051","rootId":"3056243","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Lines
+        in the Sand","releaseYear":2006,"releaseDate":"2006-09-26","origAirDate":"2006-09-26","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House takes the case of an autistic 10-year-old who screams for no apparent
+        reason, then House refuses to use his office after Cuddy makes a minor change.","shortDescription":"House
+        takes the case of an autistic 10-year-old who screams for no reason.","episodeNum":4,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Newton Thomas Sigel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590052","rootId":"3056244","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fools
+        for Love","releaseYear":2006,"releaseDate":"2006-10-31","origAirDate":"2006-10-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        treats a young married couple with similar symptoms, but they are shocked
+        by the cause of the illness; a walk-in patient (David Morse) stands up to
+        House.","shortDescription":"House treats a young married couple with similar
+        symptoms, but they are shocked by the cause.","episodeNum":5,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590053","rootId":"3056245","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Que
+        Sera Sera","releaseYear":2006,"releaseDate":"2006-11-07","origAirDate":"2006-11-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        being found in a coma at his apartment, a 600-pound man is admitted to the
+        hospital; House spends the night in jail after being arrested for a number
+        of violations.","shortDescription":"After being found in a coma at his apartment,
+        a 600-pound man is admitted to the hospital.","episodeNum":6,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590054","rootId":"3056246","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Son
+        of Coma Guy","releaseYear":2006,"releaseDate":"2006-11-14","origAirDate":"2006-11-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Symptoms
+        point to a possible genetic connection when House notices something about
+        the son of a man (John Larroquette) who has been in a coma for a decade; Wilson
+        confronts House about stealing his prescription pad.","shortDescription":"House
+        notices something about the son of a man who has been in a coma for a decade.","episodeNum":7,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590055","rootId":"3056247","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Whac-A-Mole","releaseYear":2006,"releaseDate":"2006-11-21","origAirDate":"2006-11-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        challenges his co-workers to correctly diagnose the ailment of an 18-year-old
+        heart-attack patient (Patrick Fugit).","shortDescription":"House challenges
+        his co-workers to correctly diagnose an ailment.","episodeNum":8,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590056","rootId":"3056248","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Finding
+        Judas","releaseYear":2006,"releaseDate":"2006-11-28","origAirDate":"2006-11-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        takes the divorced parents of a young patient to court when their bickering
+        prevents a decision on her treatment.","shortDescription":"House takes the
+        parents of a young patient to court when their bickering impedes treatment.","episodeNum":9,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590057","rootId":"3056249","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Merry
+        Little Christmas","releaseYear":2006,"releaseDate":"2006-12-12","origAirDate":"2006-12-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"House
+        is furious about Wilson striking a deal with Tritter, and at the same time,
+        he tries to diagnose a little person''s serious illness.","shortDescription":"House
+        is furious with Wilson; he tries to diagnose a little person''s serious illness.","episodeNum":10,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Tony To","Liz Friedman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Christmas","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590059","rootId":"3056251","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Words
+        and Deeds","releaseYear":2007,"releaseDate":"2007-01-09","origAirDate":"2007-01-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        makes a shocking revelation in a bid to save himself from jail time; a firefighter
+        chooses to have a risky, radical treatment on his brain in order to keep a
+        secret.","shortDescription":"House makes a shocking revelation in a bid to
+        save himself from jail time.","episodeNum":11,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590060","rootId":"3056252","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"One
+        Day, One Room","releaseYear":2007,"releaseDate":"2007-01-30","origAirDate":"2007-01-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        returns to the hospital after a short stint in rehab; Cuddy comes to collect
+        on the debt of perjuring herself for House; House encounters a patient who
+        tests positive for an STD and says she was raped recently.","shortDescription":"House
+        returns to the hospital after a short stint in rehab; a young rape victim
+        comes in.","episodeNum":12,"seasonNum":3,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590061","rootId":"3056253","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Needle
+        in a Haystack","releaseYear":2007,"releaseDate":"2007-02-06","origAirDate":"2007-02-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        16-year-old patient has internal bleeding, but his Gypsy parents arrive and
+        refuse all modern medical treatment.","shortDescription":"A teen patient has
+        internal bleeding, but his parents refuse all modern medical treatment.","episodeNum":13,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H43M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590062","rootId":"3056254","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Insensitive","releaseYear":2007,"releaseDate":"2007-02-13","origAirDate":"2007-02-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        snowstorm leaves the ER short-staffed on Valentine''s Day; House determines
+        that Foreman''s patient, who was injured in a car accident, has a rare condition
+        that makes her completely insensitive to pain.","shortDescription":"House
+        determines that a patient has a rare condition that makes her completely insensitive
+        to pain.","episodeNum":14,"seasonNum":3,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590063","rootId":"3056255","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Half-Wit","releaseYear":2007,"releaseDate":"2007-03-06","origAirDate":"2007-03-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        35-year-old musical savant (Dave Matthews) is admitted to the hospital with
+        a rare movement disorder; Cameron discovers that House has been in contact
+        with a Massachusetts hospital.","shortDescription":"A 35-year-old musical
+        savant is admitted to the hospital with a rare movement disorder.","episodeNum":15,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590064","rootId":"3056256","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Top
+        Secret","releaseYear":2007,"releaseDate":"2007-03-27","origAirDate":"2007-03-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House''s
+        newest patient, an ex-Marine who had saved House''s life in a dream the night
+        before, intrigues him.","shortDescription":"House''s newest patient saved
+        his life in a dream the night before.","episodeNum":16,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590065","rootId":"3056257","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fetal
+        Position","releaseYear":2007,"releaseDate":"2007-04-03","origAirDate":"2007-04-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        pregnant photographer collapses in the midst of a photo shoot with a famous
+        musician (Tyson Ritter); Foreman and Cuddy learn about Cameron and Chase''s
+        secret relationship.","shortDescription":"A pregnant photographer collapses
+        during a photo shoot with a famous musician.","episodeNum":17,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590066","rootId":"3056258","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Airborne","releaseYear":2007,"releaseDate":"2007-04-10","origAirDate":"2007-04-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a man next to House on a flight from Singapore to the United States becomes
+        violently ill, Cuddy suspects he has a deadly contagious virus.","shortDescription":"Cuddy
+        suspects an airplane passenger has a deadly contagious virus.","episodeNum":18,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Elodie Keene"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590067","rootId":"3056259","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Act
+        Your Age","releaseYear":2007,"releaseDate":"2007-04-17","origAirDate":"2007-04-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a 6-year-old girl collapses at day care, the team discovers that she has a
+        condition that is common in much older patients; tension develops between
+        Cameron and Chase.","shortDescription":"A 6-year-old girl collapses at day
+        care; tension develops between Cameron and Chase.","episodeNum":19,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590139","rootId":"3344957","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590068","rootId":"3056260","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House
+        Training","releaseYear":2007,"releaseDate":"2007-04-24","origAirDate":"2007-04-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a young scam artist passes out while working a card-playing scheme, Foreman
+        suspects her condition stems from drug abuse; Cuddy and Wilson go on a date
+        to an art exhibit.","shortDescription":"A young scam artist passes out while
+        working a card-playing scheme.","episodeNum":20,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Paul McCrane"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590141","rootId":"3344959","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-04-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590069","rootId":"3056261","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Family","releaseYear":2007,"releaseDate":"2007-05-01","origAirDate":"2007-05-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Wilson
+        prepares a 14-year-old leukemia patient for a last-resort bone-marrow transplant
+        from his younger brother; a mistake that killed a patient a week earlier haunts
+        Foreman.","shortDescription":"Wilson prepares a 14-year-old leukemia patient
+        for a bone-marrow transplant.","episodeNum":21,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590142","rootId":"3344960","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590070","rootId":"3056262","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Resignation","releaseYear":2007,"releaseDate":"2007-05-08","origAirDate":"2007-05-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        19-year-old college student goes to the hospital after coughing up blood during
+        karate class; House takes a special interest in an attractive nutritionist
+        (Piper Perabo), who accompanied her boyfriend to the clinic.","shortDescription":"House
+        takes a special interest in an attractive nutritionist.","episodeNum":22,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Martha Mitchell"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590071","rootId":"3056263","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Jerk","releaseYear":2007,"releaseDate":"2007-05-15","origAirDate":"2007-05-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        16-year-old chess prodigy with intense head pain and behavioral issues offends
+        the members of House''s team during his treatment.","shortDescription":"A
+        16-year-old chess prodigy offends the members of House''s team.","episodeNum":23,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590143","rootId":"3344961","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590144","rootId":"3344962","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590072","rootId":"3056264","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Human
+        Error","releaseYear":2007,"releaseDate":"2007-05-29","origAirDate":"2007-05-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team takes on the case of a woman who was rescued at sea en route from Cuba
+        in her desperate bid to get a diagnosis from Dr. House.","shortDescription":"A
+        woman escapes from Cuba in order to get a diagnosis from House.","episodeNum":24,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590145","rootId":"3344963","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590146","rootId":"3344964","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590147","rootId":"3344965","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590148","rootId":"3344966","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590149","rootId":"3344967","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590150","rootId":"3344968","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590151","rootId":"3344969","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}]}'
+  recorded_at: Sun, 27 Sep 2020 20:11:13 GMT
+- request:
+    method: get
+    uri: https://data.tmsapi.com/v1.1/series/185044/episodes?api_key=<TMS_API_KEY>&offset=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7159
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:10:33 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1b-05.mashery.com
+      Content-Length:
+      - '8463'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hitCount":267,"hits" :  [{"tmsId":"EP006883590152","rootId":"3344970","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590153","rootId":"3344971","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590154","rootId":"3344972","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590155","rootId":"3344973","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590156","rootId":"3344974","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590157","rootId":"3344975","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590158","rootId":"3344976","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590159","rootId":"3344977","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590160","rootId":"3344978","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590161","rootId":"3344979","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590162","rootId":"3344980","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590163","rootId":"3344981","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590164","rootId":"3344982","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590165","rootId":"3344983","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590073","rootId":"3056265","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Alone","releaseYear":2007,"releaseDate":"2007-09-25","origAirDate":"2007-09-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young woman survives an office-building collapse, and House discusses his
+        ideas about the case with a hospital janitor; Wilson resorts to desperate
+        measures.","shortDescription":"A young woman survives a building collapse,
+        and House discusses the case with a hospital janitor.","episodeNum":1,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590166","rootId":"3344984","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590074","rootId":"3056266","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Right Stuff","releaseYear":2007,"releaseDate":"2007-10-02","origAirDate":"2007-10-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        begins interviewing for the open positions on his team and sets the applicants
+        against one another to help treat a woman who has an unusual neurological
+        disorder.","shortDescription":"House begins interviewing for the open positions
+        on his team.","episodeNum":2,"seasonNum":4,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590167","rootId":"3344985","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590075","rootId":"3056267","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"97
+        Seconds","releaseYear":2007,"releaseDate":"2007-10-09","origAirDate":"2007-10-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        splits the final 10 fellowship candidates into two teams by gender; the teams
+        must treat a man with muscular atrophy and diagnose the cause; at his new
+        hospital, Foreman resorts to Houselike behavior to help a patient.","shortDescription":"House
+        splits the final 10 fellowship candidates into two teams by gender.","episodeNum":3,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590168","rootId":"3344986","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590169","rootId":"3344987","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590076","rootId":"3056268","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Guardian
+        Angels","releaseYear":2007,"releaseDate":"2007-10-23","origAirDate":"2007-10-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the remaining candidates must determine why a 20-year-old cosmetician
+        had a massive seizure and now has hallucinations; Foreman''s reputation precedes
+        him as he interviews for a new job; House must narrow the candidates to six.","shortDescription":"The
+        candidates must determine why a cosmetician hallucinates.","episodeNum":4,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Conseil Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590170","rootId":"3344988","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590077","rootId":"3056269","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Mirror
+        Mirror","releaseYear":2007,"releaseDate":"2007-10-30","origAirDate":"2007-10-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a patient they think is a hypochondriac, Foreman and the six fellows
+        seem to learn more about themselves than about the patient; Cameron and Chase
+        gamble on which candidate House will cut next.","shortDescription":"Foreman
+        and the fellows treat a patient they think is a hypochondriac.","episodeNum":5,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590171","rootId":"3344989","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-11-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590078","rootId":"3056270","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Whatever
+        It Takes","releaseYear":2007,"releaseDate":"2007-11-06","origAirDate":"2007-11-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        CIA recruits House to help an agent dying of an unknown illness; Foreman faces
+        resistance from the remaining fellowship candidates when they question his
+        judgment.","shortDescription":"The CIA recruits House to help an agent; the
+        fellowship candidates question Foreman''s judgment.","episodeNum":6,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590172","rootId":"3344990","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-11-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590079","rootId":"3056271","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Ugly","releaseYear":2007,"releaseDate":"2007-11-13","origAirDate":"2007-11-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        documentary film crew follows House and his team, as they treat a teenager
+        who had a heart attack prior to facial reconstruction; several of the fellowship
+        candidates distract House.","shortDescription":"A documentary film crew follows
+        House and his team, as they treat a teenager who had a heart attack.","episodeNum":7,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590173","rootId":"3344991","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-11-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590080","rootId":"3056272","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"You
+        Don''t Want to Know","releaseYear":2007,"releaseDate":"2007-11-20","origAirDate":"2007-11-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        a magician''s heart fails during an underwater escape act, House suspects
+        him of being a scam artist faking his ailments.","shortDescription":"House
+        encounters a magician whose heart failed during an act.","episodeNum":8,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Lesli Linka Glatter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590081","rootId":"3056273","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Games","releaseYear":2007,"releaseDate":"2007-11-27","origAirDate":"2007-11-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        assigns the candidates to the particularly challenging case of an uncooperative,
+        over-the-hill rock star with a history of drug abuse and civil disobedience;
+        Cuddy orders House to hire the members of his team.","shortDescription":"House
+        assigns the candidates to the case of an over-the-hill rock star.","episodeNum":9,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590175","rootId":"3344993","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-01-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590174","rootId":"3344992","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-01-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590176","rootId":"3344994","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-01-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590083","rootId":"3056275","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"It''s
+        a Wonderful Lie","releaseYear":2008,"releaseDate":"2008-01-28","origAirDate":"2008-01-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"As
+        the team runs tests to determine what caused a woman to have sudden paralysis
+        of the hands, the rest of her system begins to shut down; the team participates
+        in a gift exchange with a twist, courtesy of House.","shortDescription":"The
+        team runs tests to determine what caused a woman to experience sudden paralysis
+        of the hands.","episodeNum":10,"seasonNum":4,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Christmas","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590082","rootId":"3056274","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Frozen","releaseYear":2008,"releaseDate":"2008-02-03","origAirDate":"2008-02-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team must treat, by way of webcam, a psychiatrist (Mira Sorvino) who
+        is stationed at the South Pole; the identity of Wilson''s love interest surprises
+        House.","shortDescription":"House and his team must treat a psychiatrist in
+        Antarctica by way of webcam.","episodeNum":11,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590177","rootId":"3344995","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590084","rootId":"3056276","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Don''t
+        Ever Change","releaseYear":2008,"releaseDate":"2008-02-05","origAirDate":"2008-02-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team consider foul play while treating a woman who collapsed at her
+        wedding; Wilson''s newly revealed relationship preoccupies House.","shortDescription":"House
+        and the team treat a woman who collapsed at her wedding.","episodeNum":12,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590178","rootId":"3344996","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590179","rootId":"3344997","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590180","rootId":"3344998","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590181","rootId":"3344999","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590182","rootId":"3345000","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590183","rootId":"3345001","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590184","rootId":"3345002","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590185","rootId":"3345003","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590186","rootId":"3345004","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590187","rootId":"3345005","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590188","rootId":"3345006","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590085","rootId":"3056277","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"No
+        More Mr. Nice Guy","releaseYear":2008,"releaseDate":"2008-04-28","origAirDate":"2008-04-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        suspects a patient has a bigger problem than the original diagnosis; House
+        and Amber argue about how much time they each get to spend with Wilson; Cuddy
+        demands that House give his team performance reviews.","shortDescription":"House
+        suspects a patient has a bigger problem than what he was originally diagnosed
+        with.","episodeNum":13,"seasonNum":4,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590189","rootId":"3345007","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590086","rootId":"3056278","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Living
+        the Dream","releaseYear":2008,"releaseDate":"2008-05-05","origAirDate":"2008-05-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        takes matters into his own hands when he feels certain that one of the actors
+        on his favorite soap opera (Jason Lewis) is suffering from a serious medical
+        condition, but the actor dismisses House''s assessment.","shortDescription":"House
+        is sure one of the actors on his favorite soap opera has a serious medical
+        condition.","episodeNum":14,"seasonNum":4,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590087","rootId":"3056279","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House''s
+        Head","releaseYear":2008,"releaseDate":"2008-05-12","origAirDate":"2008-05-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":1,"totalParts":2},"longDescription":"A
+        bus accident robs House of several hours, and as his memory slowly returns,
+        he realizes that one of his fellow passengers was exhibiting signs of a deadly
+        illness, so he races to unlock the secrets in his brain.","shortDescription":"After
+        a bus accident House realizes one of the passengers was exhibiting signs of
+        a deadly illness.","episodeNum":15,"seasonNum":4,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590088","rootId":"3056280","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Wilson''s
+        Heart","releaseYear":2008,"releaseDate":"2008-05-19","origAirDate":"2008-05-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":2,"totalParts":2},"longDescription":"House''s
+        murky memories of the bus crash test his friendship with Wilson and threaten
+        to change their lives forever.","shortDescription":"House''s murky memories
+        of the bus crash test his friendship with Wilson.","episodeNum":16,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590191","rootId":"3345009","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590190","rootId":"3345008","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590192","rootId":"3345010","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590090","rootId":"3056282","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Dying
+        Changes Everything","releaseYear":2008,"releaseDate":"2008-09-14","origAirDate":"2008-09-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Still
+        mourning the death of his girlfriend, Wilson resigns from Princeton Plainsboro;
+        House must determine if he is responsible for the death of his best friend''s
+        girlfriend; Thirteen struggles to treat a patient objectively.","shortDescription":"Still
+        mourning the death of his girlfriend, Wilson resigns from Princeton Plainsboro.","episodeNum":1,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590193","rootId":"3345011","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","ratings":[{"body":"Canadian
+        Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590091","rootId":"3056283","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Not
+        Cancer","releaseYear":2008,"releaseDate":"2008-09-23","origAirDate":"2008-09-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team investigate a string of deaths centering around a single organ
+        donor, then rush to save the only two surviving recipients; House auditions
+        new best friends and uses a detective to spy on Wilson.","shortDescription":"House
+        and the team investigate a string of deaths centering around a single organ
+        donor.","episodeNum":2,"seasonNum":5,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590194","rootId":"3345012","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590092","rootId":"3056284","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Adverse
+        Events","releaseYear":2008,"releaseDate":"2008-09-30","origAirDate":"2008-09-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team take on the case of a struggling artist with an undiagnosed illness
+        that''s distorting his perception and threatening his career; House continues
+        to have a private investigator dig up dirt on everyone on his team.","shortDescription":"House
+        and the team take on the case of a struggling artist with an undiagnosed illness.","episodeNum":3,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590195","rootId":"3345013","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590196","rootId":"3345014","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590093","rootId":"3056285","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Birthmarks","releaseYear":2008,"releaseDate":"2008-10-14","origAirDate":"2008-10-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        receiving word that his father has passed away, House is coerced into attending
+        the funeral; the team tries to diagnose the illness of a woman who was in
+        China searching for her birth mother.","shortDescription":"House attends a
+        funeral; the team tries to diagnose the illness of a woman who was in China.","episodeNum":4,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590197","rootId":"3345015","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","ratings":[{"body":"Canadian
+        Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590094","rootId":"3056286","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Lucky
+        Thirteen","releaseYear":2008,"releaseDate":"2008-10-21","origAirDate":"2008-10-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Thirteen''s
+        date gets ill after a night of partying, and House takes on her case; Foreman
+        confronts Thirteen about her self-destructive lifestyle; private investigator
+        Lucas is hot on Wilson''s trail.","shortDescription":"Thirteen''s date falls
+        ill after a night of partying, and House takes on her case.","episodeNum":5,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590198","rootId":"3345016","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"ratings":[{"body":"Canadian
+        Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590095","rootId":"3056287","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Joy","releaseYear":2008,"releaseDate":"2008-10-28","origAirDate":"2008-10-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team takes on the case of a sleepwalking patient experiencing unexplained
+        blackouts; House discovers that Cuddy is planning to adopt a baby that is
+        due in two weeks.","shortDescription":"The team treats a sleepwalking patient
+        experiencing unexplained blackouts.","episodeNum":6,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590199","rootId":"3345017","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590200","rootId":"3345018","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590096","rootId":"3056288","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Itch","releaseYear":2008,"releaseDate":"2008-11-11","origAirDate":"2008-11-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat an agoraphobic who adamantly refuses to leave his home
+        and get treatment at the hospital; Chase and Cameron try to work through some
+        kinks in their relationship; House deals with an itch he can''t seem to scratch.","shortDescription":"House
+        and the team treat an agoraphobic who adamantly refuses to leave his home.","episodeNum":7,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590201","rootId":"3345019","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590097","rootId":"3056289","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Emancipation","releaseYear":2008,"releaseDate":"2008-11-18","origAirDate":"2008-11-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        emancipated minor (Emily Rios) working as a factory manager falls ill on the
+        job; Foreman takes on a pediatric case that has him questioning whether he
+        can function without House''s oversight.","shortDescription":"An emancipated
+        minor working as a factory manager falls ill on the job.","episodeNum":8,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Jim Hayman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590202","rootId":"3345020","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590098","rootId":"3056290","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Last
+        Resort","releaseYear":2008,"releaseDate":"2008-11-25","origAirDate":"2008-11-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man (Zeljko Ivanek) willing to kill or die for a diagnosis takes House, Thirteen
+        and a number of patients hostage in Cuddy''s office, where House tries to
+        come up with the correct diagnosis.","shortDescription":"A man willing to
+        kill or die for a diagnosis takes House and several patients hostage.","episodeNum":9,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H51M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590203","rootId":"3345021","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-12-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590099","rootId":"3056291","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Let
+        Them Eat Cake","releaseYear":2008,"releaseDate":"2008-12-02","origAirDate":"2008-12-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a high-profile fitness trainer who collapses while shooting
+        an infomercial; Thirteen participates in a clinical trial led by Foreman.","shortDescription":"A
+        high-profile fitness trainer collapses while shooting an infomercial.","episodeNum":10,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590100","rootId":"3056292","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Joy
+        to the World","releaseYear":2008,"releaseDate":"2008-12-09","origAirDate":"2008-12-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"House
+        and the team treat a teenager who collapsed during her high-school Christmas
+        program; Foreman and Thirteen''s relationship progresses; Cuddy receives an
+        unexpected gift.","shortDescription":"Foreman and Thirteen''s relationship
+        progresses; unexpected gift.","episodeNum":11,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Christmas","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590204","rootId":"3345022","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-12-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590205","rootId":"3345023","seriesId":"185044","subType":"Series","title":"House","releaseYear":2009,"releaseDate":"2009","origAirDate":"2009-01-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590206","rootId":"3345024","seriesId":"185044","subType":"Series","title":"House","releaseYear":2009,"releaseDate":"2009","origAirDate":"2009-01-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590101","rootId":"3056293","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Painless","releaseYear":2009,"releaseDate":"2009-01-19","origAirDate":"2009-01-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team try to diagnose a man''s severe, chronic pain; Thirteen and Foreman
+        explore their complicated relationship; Cuddy discovers that caring for her
+        baby leaves her with little time to run the hospital.","shortDescription":"House
+        and the team try to diagnose a man''s severe, chronic pain.","episodeNum":12,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590207","rootId":"3345025","seriesId":"185044","subType":"Series","title":"House","releaseYear":2009,"releaseDate":"2009","origAirDate":"2009-01-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590102","rootId":"3056294","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Big
+        Baby","releaseYear":2009,"releaseDate":"2009-01-26","origAirDate":"2009-01-26","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Cuddy
+        gives some of her day-to-day responsibilities to Cameron; the team takes on
+        the case of a teacher who collapsed after spitting up blood during a class.","shortDescription":"The
+        team takes on the case of a teacher who collapsed after spitting up blood
+        during a class.","episodeNum":13,"seasonNum":5,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590103","rootId":"3056295","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Greater Good","releaseYear":2009,"releaseDate":"2009-02-02","origAirDate":"2009-02-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a former cancer researcher who gave up her career to pursue her own
+        personal happiness, House and his staff begin to question their own choices;
+        Thirteen begins to show serious reactions to her experimental treatment.","shortDescription":"House
+        and his staff begin to question their life choices while treating a former
+        cancer researcher.","episodeNum":14,"seasonNum":5,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Lesli Linka Glatter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590104","rootId":"3056296","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Unfaithful","releaseYear":2009,"releaseDate":"2009-02-16","origAirDate":"2009-02-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        priest is admitted to the ER after he sees a bleeding Jesus hovering at his
+        doorstep; House confronts Thirteen and Foreman about their relationship.","shortDescription":"A
+        priest is admitted to the ER after he sees a bleeding Jesus hovering at his
+        doorstep.","episodeNum":15,"seasonNum":5,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590105","rootId":"3056297","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Softer Side","releaseYear":2009,"releaseDate":"2009-02-23","origAirDate":"2009-02-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a teenager who doesn''t know that he has genetic mosaicism; Wilson
+        and Cuddy think something is wrong with House when he starts acting nice.","shortDescription":"The
+        team treats a teenager who doesn''t know that he has genetic mosaicism.","episodeNum":16,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590106","rootId":"3056298","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Social Contract","releaseYear":2009,"releaseDate":"2009-03-09","origAirDate":"2009-03-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a patient who speaks his mind uncontrollably; House thinks
+        Taub and Wilson are keeping something from him.","shortDescription":"House
+        and the team treat a patient who speaks his mind uncontrollably.","episodeNum":17,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590107","rootId":"3056299","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Here
+        Kitty","releaseYear":2009,"releaseDate":"2009-03-16","origAirDate":"2009-03-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        sets out to disprove the allegations of a nursing home worker who feigns illness
+        after being visited by the facility''s pet cat, which has a reputation for
+        visiting people who are about to die.","shortDescription":"House sets out
+        to disprove the allegations of a nursing home worker who feigns illness.","episodeNum":18,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590108","rootId":"3056300","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Locked
+        In","releaseYear":2009,"releaseDate":"2009-03-30","origAirDate":"2009-03-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man (Mos Def) awakes in a New York hospital after a bicycle accident, unable
+        to move or communicate; injured and in the next bed, Dr. House insists he
+        knows what is affecting the man and has him transferred to Princeton Plainsboro.","shortDescription":"A
+        man awakes in a New York hospital after a bicycle accident, unable to move
+        or communicate.","episodeNum":19,"seasonNum":5,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590109","rootId":"3056301","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Simple
+        Explanation","releaseYear":2009,"releaseDate":"2009-04-06","origAirDate":"2009-04-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        caring for her dying husband (Meat Loaf Aday) for several months, a woman
+        (Colleen Camp) collapses and, while his condition mysteriously improves, hers
+        deteriorates.","shortDescription":"After spending the last several months
+        caring for her dying husband, a woman collapses.","episodeNum":20,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590111","rootId":"3504211","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Saviors","releaseYear":2009,"releaseDate":"2009-04-13","origAirDate":"2009-04-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Cameron
+        asks House to accept the case of an environmental activist who collapsed at
+        a protest with mysterious symptoms.","shortDescription":"Cameron asks House
+        to accept the case of an environmental activist who collapsed at a protest.","episodeNum":21,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Matthew Penn"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590112","rootId":"3518819","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House
+        Divided","releaseYear":2009,"releaseDate":"2009-04-27","origAirDate":"2009-04-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a deaf 14-year-old who collapses while competing in a wrestling
+        match; House has trouble sleeping.","shortDescription":"A deaf 14-year-old
+        collapses while competing in a wrestling match.","episodeNum":22,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590113","rootId":"3522055","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Under
+        My Skin","releaseYear":2009,"releaseDate":"2009-05-04","origAirDate":"2009-05-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a ballerina whose lungs collapse during a performance;
+        House is desperate to find a cure for his insomnia.","shortDescription":"House
+        and the team treat a ballerina whose lungs collapse during a performance.","episodeNum":23,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590114","rootId":"3522067","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Both
+        Sides Now","releaseYear":2009,"releaseDate":"2009-05-11","origAirDate":"2009-05-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        is intrigued by a patient whose left brain and right brain operate independently,
+        creating two distinct personalities.","shortDescription":"House treats a patient
+        whose left brain and right brain operate independently.","episodeNum":24,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590221","rootId":"8179948","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Broken,
+        Part 2","releaseYear":2009,"releaseDate":"2009-09-21","origAirDate":"2009-09-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":2,"totalParts":2},"longDescription":"House
+        decides to accept treatment from Dr. Nolan in order to get his license reinstated.","shortDescription":"House
+        decides to accept treatment from Dr. Nolan in order to get his license reinstated.","episodeNum":2,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H46M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590220","rootId":"8179943","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Broken,
+        Part 1","releaseYear":2009,"releaseDate":"2009-09-21","origAirDate":"2009-09-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":1,"totalParts":2},"longDescription":"House
+        goes through detox, hoping to stop the hallucinations that tormented him;
+        Dr. Nolan refuses to sign the paperwork to reinstate House''s license until
+        House participates in his own mental recovery.","shortDescription":"House
+        goes through detox, hoping to stop the hallucinations that tormented him.","episodeNum":1,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590117","rootId":"7842531","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Epic
+        Fail","releaseYear":2009,"releaseDate":"2009-09-28","origAirDate":"2009-09-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        has surprising news for Cuddy; an ailing video game creator opts for treatments
+        suggested by people on the Internet rather than listening to the doctors;
+        Foreman tries to get House''s job.","shortDescription":"Ailing video game
+        creator opts for treatments suggested by people on the Internet.","episodeNum":3,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590118","rootId":"7849320","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Tyrant","releaseYear":2009,"releaseDate":"2009-10-05","origAirDate":"2009-10-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a controversial African politician (James Earl Jones) who has
+        fallen ill; Wilson tries to make amends with a feuding neighbor.","shortDescription":"The
+        team treats a controversial African politician who has fallen ill.","episodeNum":4,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}]}'
+  recorded_at: Sun, 27 Sep 2020 20:11:14 GMT
+- request:
+    method: get
+    uri: https://data.tmsapi.com/v1.1/series/185044/episodes?api_key=<TMS_API_KEY>&offset=200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7160
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:10:35 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1b-28.mashery.com
+      Content-Length:
+      - '9667'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hitCount":267,"hits" :  [{"tmsId":"EP006883590119","rootId":"7857554","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Instant
+        Karma","releaseYear":2009,"releaseDate":"2009-10-12","origAirDate":"2009-10-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        wealthy businessman brings his teenage son to the hospital and insists on
+        having House handle the case; Foreman and Chase prepare to present information
+        on the Dibala case.","shortDescription":"A wealthy businessman brings his
+        son to the hospital and insists on having House handle the case.","episodeNum":5,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590120","rootId":"7871176","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Brave
+        Heart","releaseYear":2009,"releaseDate":"2009-10-19","origAirDate":"2009-10-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team takes on the case of a police detective whose father, grandfather and
+        great-grandfather all died of sudden heart failure at age 40; House confronts
+        some of his ghosts.","shortDescription":"Police detective with a family history
+        of sudden heart failure.","episodeNum":6,"seasonNum":6,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590121","rootId":"7890233","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Known
+        Unknowns","releaseYear":2009,"releaseDate":"2009-11-09","origAirDate":"2009-11-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        teenage girl is brought to the hospital with severely swollen appendages after
+        a wild night out; as her condition worsens, the patient is unable to distinguish
+        fact from fiction; the doctors attend a medical conference.","shortDescription":"A
+        teenage girl is brought to the hospital with severely swollen appendages after
+        a wild night out.","episodeNum":7,"seasonNum":6,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590122","rootId":"7890261","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Teamwork","releaseYear":2009,"releaseDate":"2009-11-16","origAirDate":"2009-11-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        reclaims his role as head of diagnostics in time to treat an adult film star
+        admitted to the hospital for pulsating eye pain; Cuddy is reminded that Princeton
+        Plainsboro is not conducive to healthy personal relationships.","shortDescription":"House
+        treats an adult film star suffering from pulsating eye pain.","episodeNum":8,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590123","rootId":"7890277","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Ignorance
+        Is Bliss","releaseYear":2009,"releaseDate":"2009-11-23","origAirDate":"2009-11-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"On
+        the eve of Thanksgiving, the team treats an exceptionally brilliant physicist
+        who traded his career for a job as a courier; a myriad of strange symptoms
+        nearly stumps the doctors; the doctors wrestle with strained personal relationships.","shortDescription":"The
+        team treats an exceptionally brilliant physicist; strained relationships.","episodeNum":9,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Thanksgiving","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590125","rootId":"7923847","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Wilson","releaseYear":2009,"releaseDate":"2009-11-30","origAirDate":"2009-11-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        old friend and former patient of Wilson''s experiences paralysis in his right
+        arm; Cuddy continues her search for real estate.","shortDescription":"An old
+        friend and former patient of Wilson''s experiences paralysis in his right
+        arm.","episodeNum":10,"seasonNum":6,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Lesli Linka Glatter"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590126","rootId":"7972422","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Down Low","releaseYear":2010,"releaseDate":"2010-01-11","origAirDate":"2010-01-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        drug dealer mysteriously collapses during a sale; House and Wilson compete
+        for a new neighbor''s affection; Chase, Thirteen and Taub play a practical
+        joke.","shortDescription":"A drug dealer collapses during a sale; House and
+        Wilson compete for a neighbor''s affection.","episodeNum":11,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590127","rootId":"7993103","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Remorse","releaseYear":2010,"releaseDate":"2010-01-25","origAirDate":"2010-01-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        men on the team are charmed by an attractive female executive experiencing
+        random bouts of excruciating pain; House tries to make amends with a former
+        colleague.","shortDescription":"The men on the team are charmed by a female
+        executive experiencing random bouts of pain.","episodeNum":12,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590128","rootId":"7993340","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Moving
+        the Chains","releaseYear":2010,"releaseDate":"2010-02-01","origAirDate":"2010-02-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House''s
+        team rushes to treat an ailing college football star in time for the patient
+        to try out for the NFL; Foreman''s brother (Orlando Jones) makes a surprise
+        visit to the hospital.","shortDescription":"House''s team rushes to treat
+        an ailing college football star; Foreman''s brother visits.","episodeNum":13,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590129","rootId":"8000972","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"5
+        to 9","releaseYear":2010,"releaseDate":"2010-02-08","origAirDate":"2010-02-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        inner workings of the hospital are seen through the eyes of Dr. Cuddy.","shortDescription":"The
+        inner workings of the hospital are seen through the eyes of Dr. Cuddy.","episodeNum":14,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590130","rootId":"8029262","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Private
+        Lives","releaseYear":2010,"releaseDate":"2010-03-08","origAirDate":"2010-03-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        avid blogger experiences sudden bruising and bleeding; Wilson and House discover
+        secrets about each other.","shortDescription":"A blogger experiences sudden
+        bruising and bleeding; secrets about Wilson and House are uncovered.","episodeNum":15,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590131","rootId":"8036994","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Black
+        Hole","releaseYear":2010,"releaseDate":"2010-03-15","origAirDate":"2010-03-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        high-school senior repeatedly hallucinates after blacking out during a class
+        trip; Wilson tries to furnish his condo.","shortDescription":"A high-school
+        senior repeatedly hallucinates after blacking out during a class trip.","episodeNum":16,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590132","rootId":"8073882","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Lockdown","releaseYear":2010,"releaseDate":"2010-04-12","origAirDate":"2010-04-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        hospital is locked down when a newborn disappears from the nursery; new insights
+        about the team''s personal lives, relationships and regrets surface.","shortDescription":"The
+        hospital is locked down when a newborn disappears from the nursery.","episodeNum":17,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Hugh Laurie"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590133","rootId":"8075289","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Knight
+        Fall","releaseYear":2010,"releaseDate":"2010-04-19","origAirDate":"2010-04-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a knight from a community of men and women living according
+        to the ideals of the High Renaissance; Wilson and an ex start over.","shortDescription":"Treating
+        a knight from a community of people living according to the ideals of the
+        High Renaissance.","episodeNum":18,"seasonNum":6,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590134","rootId":"8082610","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Open
+        and Shut","releaseYear":2010,"releaseDate":"2010-04-26","origAirDate":"2010-04-26","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        woman in an open marriage suddenly becomes ill during a date with her boyfriend;
+        House tests Wilson and Sam''s relationship.","shortDescription":"A woman in
+        an open marriage suddenly becomes ill during a date with her boyfriend.","episodeNum":19,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Conseil Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590135","rootId":"8084118","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Choice","releaseYear":2010,"releaseDate":"2010-05-03","origAirDate":"2010-05-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats an ailing groom; House, Chase and Foreman visit a karaoke bar
+        during a raucous night out.","shortDescription":"The team treats an ailing
+        groom; House, Chase and Foreman visit a karaoke bar.","episodeNum":20,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590136","rootId":"8096988","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Baggage","releaseYear":2010,"releaseDate":"2010-05-10","origAirDate":"2010-05-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        recounts the case of a woman who came to the emergency room with an unexplained
+        illness and no memory of her identity.","shortDescription":"A woman arrives
+        at the ER with an unexplained illness and no recollection of her identity.","episodeNum":21,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590137","rootId":"8097036","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Help
+        Me","releaseYear":2010,"releaseDate":"2010-05-17","origAirDate":"2010-05-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team heads outside the hospital to help provide medical attention at the scene
+        of an emergency.","shortDescription":"The team heads outside the hospital
+        to help provide medical attention at the scene of an emergency.","episodeNum":22,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590223","rootId":"8284892","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Now
+        What?","releaseYear":2010,"releaseDate":"2010-09-20","origAirDate":"2010-09-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and Cuddy explore the ramifications of their feelings for each other; a colleague''s
+        illness leaves the hospital without a neurosurgeon on site.","shortDescription":"House
+        and Cuddy explore the ramifications of their feelings for each other.","episodeNum":1,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H42M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590224","rootId":"8291809","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Selfish","releaseYear":2010,"releaseDate":"2010-09-27","origAirDate":"2010-09-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        seemingly healthy 14-year-old collapses during a skateboarding exhibition;
+        House and Cuddy face the challenge of handling their romantic relationship
+        at work.","shortDescription":"A seemingly healthy 14-year-old collapses during
+        a skateboarding exhibition.","episodeNum":2,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590225","rootId":"8306277","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Unwritten","releaseYear":2010,"releaseDate":"2010-10-04","origAirDate":"2010-10-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        popular children''s author has a seizure moments before attempting suicide;
+        House and Cuddy go on a date with Wilson and his girlfriend (Cynthia Watros).","shortDescription":"A
+        popular children''s author has a seizure moments before attempting suicide.","episodeNum":3,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590226","rootId":"8317788","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Massage
+        Therapy","releaseYear":2010,"releaseDate":"2010-10-11","origAirDate":"2010-10-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team make unexpected discoveries about a female patient admitted to
+        the hospital after severe and uncontrollable vomiting; House and Cuddy are
+        forced to face the reservations in their relationship after a visit from a
+        massage therapist.","shortDescription":"House and his team make unexpected
+        discoveries about a female patient admitted to the hospital.","episodeNum":4,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590227","rootId":"8327760","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Unplanned
+        Parenthood","releaseYear":2010,"releaseDate":"2010-10-18","origAirDate":"2010-10-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        newborn experiences breathing problems and liver failure; House requests a
+        female doctor be hired for the team; Cuddy asks House to baby-sit.","shortDescription":"A
+        newborn experiences breathing problems and liver failure; Cuddy asks House
+        to baby-sit.","episodeNum":5,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590228","rootId":"8362680","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Office
+        Politics","releaseYear":2010,"releaseDate":"2010-11-06","origAirDate":"2010-11-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        chooses a third-year medical student (Amber Tamblyn) when Cuddy forces him
+        to hire a female team member; a politician''s campaign manager mysteriously
+        falls ill with liver failure and temporary paralysis.","shortDescription":"House
+        chooses a third-year medical student when Cuddy forces him to hire a female
+        team member.","episodeNum":6,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590229","rootId":"8364004","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"A
+        Pox on Our House","releaseYear":2010,"releaseDate":"2010-11-15","origAirDate":"2010-11-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a 200-year-old medicine jar shatters in a teenager''s palm, she is admitted
+        to the hospital with symptoms closely linked to smallpox; House must make
+        a dangerous decision that puts his life in jeopardy; Wilson and Sam comfort
+        a young patient.","shortDescription":"A teenager is admitted to the hospital
+        with symptoms closely linked to smallpox.","episodeNum":7,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tucker Gates"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590230","rootId":"8364053","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Small
+        Sacrifices","releaseYear":2010,"releaseDate":"2010-11-22","origAirDate":"2010-11-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man becomes a patient after re-enacting the Crucifixion; Taub questions his
+        wife about her relationship with a member of an infidelity support group;
+        Wilson''s relationship with Sam takes an unexpected turn at a co-worker''s
+        wedding.","shortDescription":"A man becomes a patient after re-enacting the
+        Crucifixion; Dr. Taub questions his wife.","episodeNum":8,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590231","rootId":"8473417","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Larger
+        Than Life","releaseYear":2011,"releaseDate":"2011-01-17","origAirDate":"2011-01-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        saving a stranger who fell onto subway tracks, a man suddenly collapses despite
+        appearing to be unscathed; House tries to avoid a dinner with Cuddy and her
+        opinionated mother (Candice Bergen).","shortDescription":"After saving a stranger
+        who fell onto subway tracks, a man collapses despite appearing unscathed.","episodeNum":9,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590232","rootId":"8492313","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Carrot
+        or Stick","releaseYear":2011,"releaseDate":"2011-01-24","origAirDate":"2011-01-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        boot-camp trainee and his drill sergeant exhibit the same peculiar symptoms;
+        an indecent photo of Chase is posted online; House helps prepare Rachel for
+        enrollment at a prestigious preschool.","shortDescription":"A boot-camp trainee
+        and his drill sergeant exhibit the same peculiar symptoms.","episodeNum":10,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590234","rootId":"8511393","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Family
+        Practice","releaseYear":2011,"releaseDate":"2011-02-07","origAirDate":"2011-02-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        Cuddy''s mother (Candice Bergen) complains of unusual symptoms, she is admitted
+        to the hospital; Masters questions her principles.","shortDescription":"After
+        Cuddy''s mother complains of unusual symptoms, she is admitted to the hospital.","episodeNum":11,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590233","rootId":"8503083","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"You
+        Must Remember This","releaseYear":2011,"releaseDate":"2011-02-14","origAirDate":"2011-02-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        woman with an extraordinary memory experiences temporary paralysis, and a
+        visit from her sister triggers more health complications; Foreman helps Taub
+        prepare for an exam; House discovers Wilson''s new secret companion.","shortDescription":"A
+        woman with an extraordinary memory experiences temporary paralysis.","episodeNum":12,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590235","rootId":"8520448","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Two
+        Stories","releaseYear":2011,"releaseDate":"2011-02-21","origAirDate":"2011-02-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        shares explicit medical stories with students at a school''s career day; two
+        fifth-graders try to help House understand how his antics prevent him from
+        showing Cuddy how he feels.","shortDescription":"House shares explicit medical
+        stories with students at a school''s career day.","episodeNum":13,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590236","rootId":"8520551","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Recession
+        Proof","releaseYear":2011,"releaseDate":"2011-02-28","origAirDate":"2011-02-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        patient has a severe rash after being exposed to caustic chemicals at work;
+        House must choose between attending a charity event to support Cuddy and staying
+        with his patient; Chase and Masters learn about relationships.","shortDescription":"A
+        patient has a severe rash after being exposed to caustic chemicals at work.","episodeNum":14,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["S.J. Clarkson"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590237","rootId":"8542303","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Bombshells","releaseYear":2011,"releaseDate":"2011-03-07","origAirDate":"2011-03-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Cuddy
+        receives news that forces her to re-evaluate her priorities; a teenage patient''s
+        suspicious body scars suggest his illness is more than physical.","shortDescription":"A
+        teenage patient''s suspicious body scars suggest his illness is more than
+        physical.","episodeNum":15,"seasonNum":7,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590238","rootId":"8551448","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Out
+        of the Chute","releaseYear":2011,"releaseDate":"2011-03-14","origAirDate":"2011-03-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        professional bull-rider needs risky open-heart surgery after being attacked
+        by the animal; Masters develops a crush on a patient, surprising Taub.","shortDescription":"A
+        professional bull-rider needs risky open-heart surgery; Masters develops a
+        crush on a patient.","episodeNum":16,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590239","rootId":"8565210","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fall
+        From Grace","releaseYear":2011,"releaseDate":"2011-03-21","origAirDate":"2011-03-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young homeless man and former drug addict is found in a park with scars and
+        burn marks on his chest; Cuddy expresses her guilt to Wilson.","shortDescription":"A
+        young homeless man and former drug addict is found with scars and burn marks
+        on his chest.","episodeNum":17,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Tucker Gates"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590240","rootId":"8594609","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Dig","releaseYear":2011,"releaseDate":"2011-04-11","origAirDate":"2011-04-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        learning that Thirteen spent time in prison, House tries to figure out why
+        she was incarcerated; the team makes a discovery about a teacher who has severe
+        respiratory problems.","shortDescription":"House discovers Thirteen spent
+        time in prison; treating a teacher with respiratory problems.","episodeNum":18,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590241","rootId":"8605560","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Last
+        Temptation","releaseYear":2011,"releaseDate":"2011-04-18","origAirDate":"2011-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team;
+        a 16-year-old collapses days before embarking on a sailing tour of the globe.","shortDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team.","episodeNum":19,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tim Southam"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590278","rootId":"8605560","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"La
+        \u00faltima tentaci\u00f3n","releaseYear":2011,"releaseDate":"2011-04-18","origAirDate":"2011-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team;
+        a 16-year-old collapses days before embarking on a sailing tour of the globe.","shortDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team.","episodeNum":19,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tim Southam"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590242","rootId":"8637687","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Changes","releaseYear":2011,"releaseDate":"2011-05-02","origAirDate":"2011-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        lottery winner experiences partial paralysis while looking for a long-lost
+        love; medical licenses are jeopardized when Cuddy''s mother (Candice Bergen)
+        threatens to sue the hospital.","shortDescription":"A lottery winner experiences
+        partial paralysis; Cuddy''s mother threatens to sue the hospital.","episodeNum":20,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590277","rootId":"8637687","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Cambios","releaseYear":2011,"releaseDate":"2011-05-02","origAirDate":"2011-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        lottery winner experiences partial paralysis while looking for a long-lost
+        love; medical licenses are jeopardized when Cuddy''s mother (Candice Bergen)
+        threatens to sue the hospital.","shortDescription":"A lottery winner experiences
+        partial paralysis; Cuddy''s mother threatens to sue the hospital.","episodeNum":20,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590243","rootId":"8638621","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Fix","releaseYear":2011,"releaseDate":"2011-05-09","origAirDate":"2011-05-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and Wilson disagree on the outcome of a boxing match they bet on; the team
+        suspects House of having another drug problem.","shortDescription":"House
+        and Wilson disagree on the outcome of a boxing match they bet on.","episodeNum":21,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590244","rootId":"8638673","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"After
+        Hours","releaseYear":2011,"releaseDate":"2011-05-16","origAirDate":"2011-05-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Thirteen
+        turns to Chase when a friend comes to her in need of medical attention and
+        can''t be taken to the hospital; House gets devastating news.","shortDescription":"Thirteen
+        turns to Chase for help when a friend comes to her in need of medical attention.","episodeNum":22,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590245","rootId":"8638724","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Moving
+        On","releaseYear":2011,"releaseDate":"2011-05-23","origAirDate":"2011-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team questions the necessity of the treatments it is giving a performance
+        artist; House''s unexpected action may forever change his relationships with
+        Wilson and Cuddy.","shortDescription":"The team questions the necessity of
+        a performance artist''s treatments; House acts unexpectedly.","episodeNum":23,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590279","rootId":"8638724","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"La
+        vida sigue","releaseYear":2011,"releaseDate":"2011-05-23","origAirDate":"2011-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team questions the necessity of the treatments it is giving a performance
+        artist; House''s unexpected action may forever change his relationships with
+        Wilson and Cuddy.","shortDescription":"The team questions the necessity of
+        a performance artist''s treatments; House acts unexpectedly.","episodeNum":23,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590247","rootId":"8856622","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Twenty
+        Vicodin","releaseYear":2011,"releaseDate":"2011-10-03","origAirDate":"2011-10-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        notices strange symptoms in a fellow inmate at the East New Jersey Correctional
+        Facility; a clinic doctor must decide whether to risk her job by helping House.","shortDescription":"House
+        notices strange symptoms in a fellow inmate at the East New Jersey Correctional
+        Facility.","episodeNum":1,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590248","rootId":"8864426","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Transplant","releaseYear":2011,"releaseDate":"2011-10-10","origAirDate":"2011-10-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        unexpected visitor offers House the chance to help the Princeton Plainsboro
+        team with a patient; Wilson is unreceptive to House''s attempts to reconnect.","shortDescription":"An
+        unexpected visitor offers House the chance to help the Princeton Plainsboro
+        team with a patient.","episodeNum":2,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590249","rootId":"8874808","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Charity
+        Case","releaseYear":2011,"releaseDate":"2011-10-17","origAirDate":"2011-10-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a man (Wentworth Miller) collapses after making a generous donation, House
+        and Dr. Chi Park try to identify his medical disorder; Thirteen''s pursuit
+        of happiness is hampered by feelings of guilt.","shortDescription":"When a
+        generous man collapses, House and Dr. Chi Park try to identify his medical
+        disorder.","episodeNum":3,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590250","rootId":"8897519","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Risky
+        Business","releaseYear":2011,"releaseDate":"2011-10-31","origAirDate":"2011-10-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        businessman (Michael Nouri) becomes ill days before signing a contract that
+        would relocate his company''s labor force to China; Park prepares for her
+        hearing with the hospital''s disciplinary committee.","shortDescription":"A
+        businessman becomes ill days before signing a contract that relocates his
+        company''s labor force.","episodeNum":4,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590251","rootId":"8898336","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Confession","releaseYear":2011,"releaseDate":"2011-11-07","origAirDate":"2011-11-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        patient confesses dark secrets to his family and community, compromising his
+        chances of receiving life-saving medical treatment; Chase and Taub rejoin
+        the team; Taub struggles to balance work and fatherhood.","shortDescription":"A
+        patient confesses dark secrets to his community, compromising his chances
+        of survival.","episodeNum":5,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Kate Woods"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590252","rootId":"8898360","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Parents","releaseYear":2011,"releaseDate":"2011-11-14","origAirDate":"2011-11-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team discovers a disturbing family secret while trying to find a bone marrow
+        match for an ailing teen; House tries to remove his ankle monitor so he can
+        go to a boxing match; Taub''s ex-wife wants to move across the country with
+        their daughter.","shortDescription":"The team discovers a disturbing family
+        secret while trying to find a bone marrow match for a teen.","episodeNum":6,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590253","rootId":"8898416","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Dead
+        & Buried","releaseYear":2011,"releaseDate":"2011-11-21","origAirDate":"2011-11-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team discovers its teenage patient isn''t just being dramatic when her symptoms
+        worsen; House becomes consumed with determining the cause of a 4-year-old''s
+        death; Park tries to get Chase to admit why he has become obsessed with grooming.","shortDescription":"The
+        team discovers its teenage patient isn''t just being dramatic when her symptoms
+        worsen.","episodeNum":7,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590254","rootId":"8941367","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Perils
+        of Paranoia","releaseYear":2011,"releaseDate":"2011-11-28","origAirDate":"2011-11-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"During
+        an interrogation at the witness stand, a prosecutor has what he thinks is
+        a heart attack; Wilson is determined to prove that House is hiding something;
+        Park starts to come out of her shell.","shortDescription":"During an interrogation,
+        a prosecutor has what he thinks is a heart attack.","episodeNum":8,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590257","rootId":"9029454","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Better
+        Half","releaseYear":2012,"releaseDate":"2012-01-23","origAirDate":"2012-01-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        Alzheimer''s patient participating in a drug trial suffers from a violent
+        temper; Wilson treats a patient who claims to be in a chaste marriage.","shortDescription":"An
+        Alzheimer''s patient participating in a drug trial suffers from a violent
+        temper.","episodeNum":9,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590258","rootId":"9038453","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Runaways","releaseYear":2012,"releaseDate":"2012-01-30","origAirDate":"2012-01-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a homeless teenager''s (Bridgit Mendler) symptoms get worse, adult consent
+        is required for an invasive surgery; Taub tries to connect with his daughters;
+        House threatens Foreman''s relationship with a married woman (Yaya DaCosta).","shortDescription":"When
+        a homeless teenager''s symptoms get worse, adult consent is required for an
+        invasive surgery.","episodeNum":10,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590259","rootId":"9053495","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Nobody''s
+        Fault","releaseYear":2012,"releaseDate":"2012-02-06","origAirDate":"2012-02-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        Walter Cofield (Jeffrey Wright), Foreman''s former mentor, places House and
+        the team under review after a violent incident involving a patient.","shortDescription":"House
+        and the team are placed under review after a violent incident involving a
+        patient.","episodeNum":11,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590260","rootId":"9066285","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Chase","releaseYear":2012,"releaseDate":"2012-02-13","origAirDate":"2012-02-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"As
+        Chase treats Moira (Julie Mond), a cloistered nun who is on the verge of making
+        life-altering vows, they form a connection that causes Moira to question her
+        faith; Taub and House take part in a series of pranks.","shortDescription":"As
+        Chase treats Moira, a nun, they form a connection that causes Moira to question
+        her faith.","episodeNum":12,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590261","rootId":"9078572","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Man
+        of the House","releaseYear":2012,"releaseDate":"2012-02-20","origAirDate":"2012-02-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team notices behavioral changes in a marriage counselor who collapsed during
+        a speaking engagement; House and Dominka work to convince Immigration they
+        are a happy couple; House chooses a team leader.","shortDescription":"The
+        team notices behavioral changes in a marriage counselor who collapsed while
+        speaking.","episodeNum":13,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Colin Bucksey"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590263","rootId":"9093461","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Love
+        Is Blind","releaseYear":2012,"releaseDate":"2012-02-27","origAirDate":"2012-03-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team works to save a blind man with a mysterious illness; House''s mother
+        makes an unexpected visit.","shortDescription":"The team works to save a blind
+        man with a mysterious illness; House''s mother visits.","episodeNum":14,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Tim Southam"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590264","rootId":"9094457","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Blowing
+        the Whistle","releaseYear":2012,"releaseDate":"2012-04-02","origAirDate":"2012-04-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats an Army veteran who refuses treatment unless he and his brother
+        are given information about their dead father; Adams seeks help when she suspects
+        House is sick.","shortDescription":"A sick Army veteran refuses treatment
+        unless he is given information about his dead father.","episodeNum":15,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Julian Higgins"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590266","rootId":"9170116","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Gut
+        Check","releaseYear":2012,"releaseDate":"2012-04-09","origAirDate":"2012-04-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        a fight on the ice, a 22-year-old minor league hockey player collapses and
+        coughs up blood; House stuns Wilson; Chase has an offer for Park.","shortDescription":"After
+        a fight on the ice, a 22-year-old minor league hockey player collapses and
+        coughs up blood.","episodeNum":16,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590267","rootId":"9181667","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"We
+        Need the Eggs","releaseYear":2012,"releaseDate":"2012-04-16","origAirDate":"2012-04-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a man who sheds tears of blood; when House acts out when
+        his favorite prostitute decides to leave the business.","shortDescription":"The
+        team treats a man who sheds tears of blood; House''s favorite prostitute quits
+        the business.","episodeNum":17,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Direcci\u00f3n General
+        de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590268","rootId":"9197169","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Body
+        & Soul","releaseYear":2012,"releaseDate":"2012-04-23","origAirDate":"2012-04-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a boy who wakes up from nightmares of being choked still unable
+        to breathe; Park has intimate dreams about co-workers; Dominika discovers
+        a secret that has the potential to ruin her relationship with House.","shortDescription":"The
+        team treats a boy who wakes up from nightmares of being choked still unable
+        to breathe.","episodeNum":18,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Stefan Schwartz"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Direcci\u00f3n General
+        de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590270","rootId":"9209458","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        C-Word","releaseYear":2012,"releaseDate":"2012-04-30","origAirDate":"2012-04-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        the team treats a 6-year-old with multiple health issues, they must collaborate
+        with her mother (Jessica Collins), who is also a doctor; Wilson and House
+        go on vacation.","shortDescription":"The team treats a 6-year-old with multiple
+        health issues; Wilson and House go on vacation.","episodeNum":19,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Hugh Laurie"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590271","rootId":"9220724","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Post
+        Mortem","releaseYear":2012,"releaseDate":"2012-05-07","origAirDate":"2012-05-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team must convince its patient that a missing House is still calling all the
+        shots.","shortDescription":"The team must convince its patient that a missing
+        House is still calling all the shots.","episodeNum":20,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Peter Weller"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590272","rootId":"9220874","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Holding
+        On","releaseYear":2012,"releaseDate":"2012-05-14","origAirDate":"2012-05-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team believes a patient''s problems are both physical and psychological; Foreman
+        tries an alternative approach with House.","shortDescription":"The team believes
+        a patient''s problems are both physical and psychological.","episodeNum":21,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590273","rootId":"9220882","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Everybody
+        Dies","releaseYear":2012,"releaseDate":"2012-05-21","origAirDate":"2012-05-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a drug addicted patient, House is forced to look at his own life,
+        future and personal demons.","shortDescription":"While treating a drug addicted
+        patient, House is forced to look at his own life and personal demons.","episodeNum":22,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["David Shore"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590265","rootId":"9159655","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Swan
+        Song","releaseYear":2012,"releaseDate":"2012-05-21","origAirDate":"2012-05-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        special episode looks back at the series so far, including interviews with
+        stars and producers.","shortDescription":"A special episode looks back at
+        the series so far, including interviews with stars and producers.","episodeNum":23,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"ratings":[{"body":"USA Parental
+        Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"16"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}]}'
+  recorded_at: Sun, 27 Sep 2020 20:11:14 GMT
 recorded_with: VCR 6.0.0

--- a/tvsharedb/test/vcr_cassettes/series_185044.yml
+++ b/tvsharedb/test/vcr_cassettes/series_185044.yml
@@ -19,19 +19,19 @@ http_interactions:
       message: OK
     headers:
       Cache-Control:
-      - max-age=7200
+      - max-age=7158
       Content-Type:
-      - application/json;charset=UTF-8
+      - application/json;charset=utf-8
       Date:
-      - Tue, 28 Jul 2020 14:25:50 GMT
+      - Sun, 27 Sep 2020 20:10:31 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding,Origin
       X-Mashery-Responder:
-      - prod-j-worker-us-west-1b-20.mashery.com
+      - prod-j-worker-us-west-1b-07.mashery.com
       Content-Length:
-      - '2365'
+      - '2376'
       Connection:
       - keep-alive
     body:
@@ -59,11 +59,11 @@ http_interactions:
         Producer","nameId":"71245","personId":"71245","name":"Paul Attanasio"},{"billingOrder":"02","role":"Executive
         Producer","nameId":"290570","personId":"286801","name":"Katie Jacobs"},{"billingOrder":"03","role":"Executive
         Producer","nameId":"203480","personId":"201573","name":"David Shore"},{"billingOrder":"04","role":"Executive
-        Producer","nameId":"160710","personId":"160143","name":"Bryan Singer"}],"awards":[{"awardId":"4","recipient":"Hugh
-        Laurie","name":"Emmy (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2005","category":"Outstanding
-        Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"4","name":"Emmy
+        Producer","nameId":"160710","personId":"160143","name":"Bryan Singer"}],"awards":[{"awardId":"4","name":"Emmy
         (Primetime)","awardName":"Emmy (Primetime)","won":"true","year":"2005","category":"Outstanding
-        Writing for a Drama Series","awardCatId":"68"},{"awardId":"2","recipient":"Hugh
+        Writing for a Drama Series","awardCatId":"68"},{"awardId":"4","recipient":"Hugh
+        Laurie","name":"Emmy (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2005","category":"Outstanding
+        Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"2","recipient":"Hugh
         Laurie","name":"Golden Globe","awardName":"Golden Globe","personId":"87269","won":"true","year":"2006","category":"Best
         Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Hugh
         Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
@@ -75,31 +75,31 @@ http_interactions:
         Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Hugh
         Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
         Awards","personId":"87269","won":"true","year":"2007","category":"Outstanding
-        Performance by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","recipient":"Hugh
-        Laurie","name":"Emmy (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2007","category":"Outstanding
-        Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"4","name":"Emmy
+        Performance by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","name":"Emmy
         (Primetime)","awardName":"Emmy (Primetime)","year":"2007","category":"Outstanding
-        Drama Series","awardCatId":"60"},{"awardId":"6","name":"British Academy of
-        Film & Television Arts","awardName":"British Academy of Film & Television
-        Arts","year":"2007","category":"International","awardCatId":"230"},{"awardId":"2","recipient":"Hugh
-        Laurie","name":"Golden Globe","awardName":"Golden Globe","personId":"87269","year":"2008","category":"Best
-        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"2","name":"Golden
+        Drama Series","awardCatId":"60"},{"awardId":"4","recipient":"Hugh Laurie","name":"Emmy
+        (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2007","category":"Outstanding
+        Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"6","name":"British
+        Academy of Film & Television Arts","awardName":"British Academy of Film &
+        Television Arts","year":"2007","category":"International","awardCatId":"230"},{"awardId":"2","name":"Golden
         Globe","awardName":"Golden Globe","year":"2008","category":"Best Television
-        Series - Drama","awardCatId":"111"},{"awardId":"3","recipient":"Hugh Laurie","name":"Screen
-        Actors Guild Awards","awardName":"Screen Actors Guild Awards","personId":"87269","year":"2008","category":"Outstanding
-        Performance by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","recipient":"Hugh
+        Series - Drama","awardCatId":"111"},{"awardId":"2","recipient":"Hugh Laurie","name":"Golden
+        Globe","awardName":"Golden Globe","personId":"87269","year":"2008","category":"Best
+        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Hugh
+        Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
+        Awards","personId":"87269","year":"2008","category":"Outstanding Performance
+        by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","name":"Emmy
+        (Primetime)","awardName":"Emmy (Primetime)","year":"2008","category":"Outstanding
+        Directing for a Drama Series","awardCatId":"57"},{"awardId":"4","recipient":"Hugh
         Laurie","name":"Emmy (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2008","category":"Outstanding
         Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"4","name":"Emmy
         (Primetime)","awardName":"Emmy (Primetime)","year":"2008","category":"Outstanding
-        Directing for a Drama Series","awardCatId":"57"},{"awardId":"4","name":"Emmy
-        (Primetime)","awardName":"Emmy (Primetime)","year":"2008","category":"Outstanding
-        Drama Series","awardCatId":"60"},{"awardId":"2","recipient":"Hugh Laurie","name":"Golden
-        Globe","awardName":"Golden Globe","personId":"87269","year":"2009","category":"Best
-        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"2","name":"Golden
-        Globe","awardName":"Golden Globe","year":"2009","category":"Best Television
-        Series - Drama","awardCatId":"111"},{"awardId":"3","recipient":"Robert Sean
-        Leonard","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
-        Awards","personId":"55541","year":"2009","category":"Outstanding Performance
+        Drama Series","awardCatId":"60"},{"awardId":"2","name":"Golden Globe","awardName":"Golden
+        Globe","year":"2009","category":"Best Television Series - Drama","awardCatId":"111"},{"awardId":"2","recipient":"Hugh
+        Laurie","name":"Golden Globe","awardName":"Golden Globe","personId":"87269","year":"2009","category":"Best
+        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Robert
+        Sean Leonard","name":"Screen Actors Guild Awards","awardName":"Screen Actors
+        Guild Awards","personId":"55541","year":"2009","category":"Outstanding Performance
         by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Omar
         Epps","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
         Awards","personId":"72370","year":"2009","category":"Outstanding Performance
@@ -127,17 +127,18 @@ http_interactions:
         by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"3","recipient":"Lisa
         Edelstein","name":"Screen Actors Guild Awards","awardName":"Screen Actors
         Guild Awards","personId":"68332","year":"2009","category":"Outstanding Performance
-        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"4","recipient":"Hugh
-        Laurie","name":"Emmy (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2009","category":"Outstanding
-        Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"4","name":"Emmy
+        by an Ensemble in a Drama Series","awardCatId":"126"},{"awardId":"4","name":"Emmy
         (Primetime)","awardName":"Emmy (Primetime)","year":"2009","category":"Outstanding
-        Drama Series","awardCatId":"60"},{"awardId":"2","recipient":"Hugh Laurie","name":"Golden
-        Globe","awardName":"Golden Globe","personId":"87269","year":"2010","category":"Best
-        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"2","name":"Golden
+        Drama Series","awardCatId":"60"},{"awardId":"4","recipient":"Hugh Laurie","name":"Emmy
+        (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2009","category":"Outstanding
+        Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"2","name":"Golden
         Globe","awardName":"Golden Globe","year":"2010","category":"Best Television
-        Series - Drama","awardCatId":"111"},{"awardId":"3","recipient":"Hugh Laurie","name":"Screen
-        Actors Guild Awards","awardName":"Screen Actors Guild Awards","personId":"87269","year":"2010","category":"Outstanding
-        Performance by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","recipient":"Hugh
+        Series - Drama","awardCatId":"111"},{"awardId":"2","recipient":"Hugh Laurie","name":"Golden
+        Globe","awardName":"Golden Globe","personId":"87269","year":"2010","category":"Best
+        Performance by an Actor in a Television Series - Drama","awardCatId":"117"},{"awardId":"3","recipient":"Hugh
+        Laurie","name":"Screen Actors Guild Awards","awardName":"Screen Actors Guild
+        Awards","personId":"87269","year":"2010","category":"Outstanding Performance
+        by a Male Actor in a Drama Series","awardCatId":"124"},{"awardId":"4","recipient":"Hugh
         Laurie","name":"Emmy (Primetime)","awardName":"Emmy (Primetime)","personId":"87269","year":"2010","category":"Outstanding
         Lead Actor in a Drama Series","awardCatId":"78"},{"awardId":"2","recipient":"Hugh
         Laurie","name":"Golden Globe","awardName":"Golden Globe","personId":"87269","year":"2011","category":"Best
@@ -158,5 +159,2301 @@ http_interactions:
         General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B15"}],"recommendations":[{"tmsId":"SH007322830000","rootId":"185019","title":"Grey''s
         Anatomy"},{"tmsId":"SH021835930000","rootId":"11770123","title":"Chicago Med"},{"tmsId":"SH026966280000","rootId":"14159582","title":"The
         Good Doctor"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}'
-  recorded_at: Tue, 28 Jul 2020 14:25:51 GMT
+  recorded_at: Sun, 27 Sep 2020 20:11:13 GMT
+- request:
+    method: get
+    uri: https://data.tmsapi.com/v1.1/series/185044/episodes?api_key=<TMS_API_KEY>&offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7158
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:10:31 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1b-24.mashery.com
+      Content-Length:
+      - '11013'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hitCount":267,"hits" :  [{"tmsId":"EP006883590215","rootId":"7838667","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590140","rootId":"3344958","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590219","rootId":"7889825","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590216","rootId":"7850276","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590214","rootId":"3550270","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590210","rootId":"3345028","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590269","rootId":"9201256","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590209","rootId":"3345027","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590213","rootId":"3537900","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590211","rootId":"3345029","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590208","rootId":"3345026","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590212","rootId":"3496354","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590124","rootId":"7899195","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590217","rootId":"7856765","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590218","rootId":"7870319","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590138","rootId":"3344956","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590222","rootId":"8216637","seriesId":"185044","subType":"Series","title":"House","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590001","rootId":"3056194","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Pilot","releaseYear":2004,"releaseDate":"2004-11-16","origAirDate":"2004-11-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House (Hugh Laurie) and his team try to save the life of a kindergarten teacher
+        (Robin Tunney) who began speaking gibberish and passed out in front of her
+        students.","shortDescription":"Dr. House and his team try to save the life
+        of a kindergarten teacher.","episodeNum":1,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Bryan Singer"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590003","rootId":"3056196","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Paternity","releaseYear":2004,"releaseDate":"2004-11-23","origAirDate":"2004-11-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House and the team think a teenage lacrosse player has multiple sclerosis
+        until the boy''s night-terrors disprove their diagnosis.","shortDescription":"Dr.
+        House and the team think a teenage lacrosse player has multiple sclerosis.","episodeNum":2,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590002","rootId":"3056195","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Occam''s
+        Razor","releaseYear":2004,"releaseDate":"2004-04-30","origAirDate":"2004-11-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        collegian collapses after raucous sex with his girlfriend, and Dr. House and
+        his team scramble to figure out why as the student''s condition worsens.","shortDescription":"A
+        collegian collapses, and House and his team scramble to figure out why.","episodeNum":3,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Bryan Singer"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590005","rootId":"3056198","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Maternity","releaseYear":2004,"releaseDate":"2004-12-07","origAirDate":"2004-12-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House annoys his boss when he suggests that two sick newborns in the hospital
+        are the start of an epidemic, but as more babies fall ill, the maternity ward
+        closes and the doctors battle over courses of treatment.","shortDescription":"Dr.
+        House annoys his boss when he suggests that two sick newborns in the hospital
+        begin an epidemic.","episodeNum":4,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Newton Thomas Sigel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590006","rootId":"3056199","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Damned
+        if You Do","releaseYear":2004,"releaseDate":"2004-12-14","origAirDate":"2004-12-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House''s approach raises questions when he treats a nun for what he believes
+        to be an allergy, not realizing that her past is coming back to haunt her.","shortDescription":"Dr.
+        House''s approach raises questions when he treats a nun for what he believes
+        is an allergy.","episodeNum":5,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590007","rootId":"3056200","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Socratic Method","releaseYear":2004,"releaseDate":"2004-12-21","origAirDate":"2004-12-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House shows special interest in a schizophrenic with deep-vein thrombosis
+        and her teenage son, who is her primary caregiver.","shortDescription":"Dr.
+        House shows special interest in a schizophrenic with deep-vein thrombosis
+        and her teenage son.","episodeNum":6,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Peter Medak"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590004","rootId":"3056197","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fidelity","releaseYear":2004,"releaseDate":"2004-12-28","origAirDate":"2004-12-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a young housewife falls ill, House suspects that she has contracted a rare
+        sexually transmitted disease, but she and her husband (Dominic Purcell) each
+        deny having an affair.","shortDescription":"House suspects a rare sexually
+        transmitted disease when a housewife falls ill.","episodeNum":7,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Bryan Spicer"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590008","rootId":"3056201","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Poison","releaseYear":2005,"releaseDate":"2005-01-25","origAirDate":"2005-01-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team investigate the mysterious poisoning of a high-school student,
+        and they think they have the answers they need until a second teen develops
+        the same symptoms.","shortDescription":"House and his team investigate the
+        mysterious poisoning of a high-school student.","episodeNum":8,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Guy Ferland"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590010","rootId":"3056203","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"DNR","releaseYear":2005,"releaseDate":"2005-02-01","origAirDate":"2005-02-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        legendary jazz musician checks into the hospital, believing he is dying of
+        ALS, and signs a \"do not resuscitate\" order, but House disagrees with the
+        diagnosis and violates the order to save the man''s life, landing himself
+        in court.","shortDescription":"House violates the DNR order of a legendary
+        musician and saves his life.","episodeNum":9,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Frederick K.
+        Keller"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590275","rootId":"3056203","seriesId":"185044","subType":"Series","title":"House","releaseYear":2005,"releaseDate":"2005-02-01","origAirDate":"2005-02-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        legendary jazz musician checks into the hospital, believing he is dying of
+        ALS, and signs a \"do not resuscitate\" order, but House disagrees with the
+        diagnosis and violates the order to save the man''s life, landing himself
+        in court.","shortDescription":"House violates the DNR order of a legendary
+        musician and saves his life.","episodeNum":9,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Frederick K.
+        Keller"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590011","rootId":"3056204","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Histories","releaseYear":2005,"releaseDate":"2005-02-08","origAirDate":"2005-02-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        Foreman believes an uncooperative homeless woman is faking seizures so she
+        can stay in the hospital, but her worsening symptoms prove to be a complex
+        mystery for Dr. House and his team.","shortDescription":"Dr. Foreman believes
+        an uncooperative homeless woman is faking seizures.","episodeNum":10,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Daniel Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590013","rootId":"3056205","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Detox","releaseYear":2005,"releaseDate":"2005-02-15","origAirDate":"2005-02-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        agrees to stop taking painkillers for a week in exchange for a month without
+        clinic duty, but the team thinks detox is affecting his judgment in the case
+        of a young man''s unexplained blood loss.","shortDescription":"House agrees
+        to stop taking painkillers for a week in exchange for a month without clinic
+        duty.","episodeNum":11,"seasonNum":1,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Nelson McCormick"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590009","rootId":"3056202","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Sports
+        Medicine","releaseYear":2005,"releaseDate":"2005-02-22","origAirDate":"2005-02-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        severely broken arm reveals underlying problems and ends the comeback plans
+        of a major league pitcher (Scott Foley), whom House suspects is taking steroids.","shortDescription":"A
+        severely broken arm reveals underlying problems for a major league pitcher.","episodeNum":12,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Keith Gordon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590014","rootId":"3056206","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Cursed","releaseYear":2005,"releaseDate":"2005-03-01","origAirDate":"2005-03-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a financial supporter of the hospital gets a divorce, his son falls ill and
+        begins to believe he is cursed, leaving House and the team trying to treat
+        him and deal with his demanding father.","shortDescription":"The team tries
+        to treat the son of a demanding financial supporter of the hospital.","episodeNum":13,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590015","rootId":"3056207","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Control","releaseYear":2005,"releaseDate":"2005-03-08","origAirDate":"2005-03-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Billionaire
+        entrepreneur Edward Vogler (Chi McBride) buys his way into becoming chairman
+        of the board with plans to use the facility as a new biotech venture, which
+        could mean the hospital no longer needs the services of Dr. House.","shortDescription":"Billionaire
+        entrepreneur Edward Vogler buys his way into becoming chairman of the board.","episodeNum":14,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Randy Zisk"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590016","rootId":"3056208","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Mob
+        Rules","releaseYear":2005,"releaseDate":"2005-03-22","origAirDate":"2005-03-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a mob informant suddenly collapses before court, House and his team try to
+        cure him or determine whether he is faking.","shortDescription":"When a mob
+        informant suddenly collapses before court, House is called upon to cure him.","episodeNum":15,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tim Hunter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590017","rootId":"3056209","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Heavy","releaseYear":2005,"releaseDate":"2005-03-29","origAirDate":"2005-03-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team blame an adverse reaction to diet pills after an obese 10-year-old
+        girl has a heart attack but, ultimately, they find another cause for her illness.","shortDescription":"House
+        and his team blame a reaction to diet pills after an obese girl has a heart
+        attack.","episodeNum":16,"seasonNum":1,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Fred Gerber"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590018","rootId":"3056210","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Role
+        Model","releaseYear":2005,"releaseDate":"2005-04-12","origAirDate":"2005-04-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        Tom Wright, a senator with presidential aspirations, becomes ill, House examines
+        him and finds that the symptoms point toward AIDS, a condition that would
+        squash his career.","shortDescription":"When Sen. Tom Wright becomes ill,
+        House examines him and finds that the symptoms point toward AIDS.","episodeNum":17,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590019","rootId":"3056211","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Babies
+        & Bathwater","releaseYear":2005,"releaseDate":"2005-04-19","origAirDate":"2005-04-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team scramble to find the cause of kidney and brain dysfunction in
+        a pregnant patient, leaving the woman and her husband to face a heartbreaking
+        choice, and Vogler continues his quest to have House fired.","shortDescription":"House
+        and his team scramble to find the cause of kidney and brain dysfunction in
+        a pregnant patient.","episodeNum":18,"seasonNum":1,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Bill Johnson"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590022","rootId":"3056214","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Kids","releaseYear":2005,"releaseDate":"2005-05-03","origAirDate":"2005-05-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        meningitis scare overwhelms the resources and staff of the hospital, but House
+        singles out a 12-year-old patient whose symptoms are similar to but not quite
+        right for the disease.","shortDescription":"A meningitis scare overwhelms
+        the resources and staff of the hospital.","episodeNum":19,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590023","rootId":"3056215","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Love
+        Hurts","releaseYear":2005,"releaseDate":"2005-05-10","origAirDate":"2005-05-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and Cameron explore their relationship; the team tries to discover what is
+        causing a young man to have blood clots and strokes.","shortDescription":"The
+        team tries to discover what is causing a young man to have blood clots and
+        strokes.","episodeNum":20,"seasonNum":1,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Bryan Spicer"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590020","rootId":"3056212","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Three
+        Stories","releaseYear":2005,"releaseDate":"2005-05-17","origAirDate":"2005-05-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        woman from Dr. House''s past returns to the hospital, where she used to be
+        legal counsel, seeking his help in diagnosing the illness her husband has.","shortDescription":"A
+        woman from Dr. House''s past returns for his help in a diagnosis.","episodeNum":21,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Paris Barclay"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590021","rootId":"3056213","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Honeymoon","releaseYear":2005,"releaseDate":"2005-05-24","origAirDate":"2005-05-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        House works to save Stacy''s husband, he cannot help but think his feelings
+        for her may have reignited.","shortDescription":"While House works to save
+        Stacy''s husband, he must deal with his feelings for her.","episodeNum":22,"seasonNum":1,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Frederick King
+        Keller"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892174_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590024","rootId":"3056216","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Acceptance","releaseYear":2005,"releaseDate":"2005-09-13","origAirDate":"2005-09-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        death row inmate Clarence mysteriously collapses after hallucinating, House
+        jumps at the case for its difficulty and because he thinks it is \"cool.\"","shortDescription":"A
+        death row inmate mysteriously collapses after hallucinating.","episodeNum":1,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590025","rootId":"3056217","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Autopsy","releaseYear":2005,"releaseDate":"2005-09-20","origAirDate":"2005-09-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        9-year-old patient with terminal cancer handles her situation so well that
+        House begins to wonder whether she is really that brave or if it is a medical
+        symptom.","shortDescription":"A child with terminal cancer copes so well that
+        House questions why.","episodeNum":2,"seasonNum":2,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590026","rootId":"3056218","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Humpty
+        Dumpty","releaseYear":2005,"releaseDate":"2005-09-27","origAirDate":"2005-09-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        Cuddy''s handyman, Alfredo, falls from her roof and develops strange symptoms,
+        she joins the team to figure out what is wrong with him.","shortDescription":"Cuddy''s
+        handyman falls from her roof and develops strange symptoms.","episodeNum":3,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590027","rootId":"3056219","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"TB
+        or Not TB","releaseYear":2005,"releaseDate":"2005-11-01","origAirDate":"2005-11-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        hospital admits a renowned physician and advocate against the spread of tuberculosis
+        in Africa, and his TB-like symptoms draw media attention which could further
+        his cause.","shortDescription":"The hospital admits a renowned physician and
+        advocate against the spread of tuberculosis in Africa.","episodeNum":4,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590028","rootId":"3056220","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Daddy''s
+        Boy","releaseYear":2005,"releaseDate":"2005-11-08","origAirDate":"2005-11-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Trust
+        issues between a father and his mysteriously ill son prevent the medical team
+        from getting the information they need to diagnose and treat the illness.","shortDescription":"Trust
+        issues between a father and his mysteriously ill son hinder a diagnosis.","episodeNum":5,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590029","rootId":"3056221","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Spin","releaseYear":2005,"releaseDate":"2005-11-15","origAirDate":"2005-11-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        resists treating a famous bicyclist, brought in after collapsing during a
+        race, because he believes the athlete is taking performance enhancers.","shortDescription":"House
+        resists treating a famous bicyclist he believes is taking performance enhancers.","episodeNum":6,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Fred Gerber"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590030","rootId":"3056222","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Hunting","releaseYear":2005,"releaseDate":"2005-11-22","origAirDate":"2005-11-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        searches for connections between the unique symptoms exhibited by a gay AIDS
+        patient and his father.","shortDescription":"House treats unique symptoms
+        exhibited by a gay AIDS patient and his father.","episodeNum":7,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Gloria Muzio"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVMA"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"18+"},{"body":"R\u00e9gie du cin\u00e9ma","code":"18+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590031","rootId":"3056223","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Mistake","releaseYear":2005,"releaseDate":"2005-11-29","origAirDate":"2005-11-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young mother with stomach pain dies, and Stacy (Sela Ward) must determine
+        whether Chase made a mistake that caused her death.","shortDescription":"Stacy
+        determines whether Chase made a mistake that caused a death.","episodeNum":8,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Semel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590032","rootId":"3056224","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Deception","releaseYear":2005,"releaseDate":"2005-12-13","origAirDate":"2005-12-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Off-track
+        betting gambler Anica (Cynthia Nixon) collapses in front of House while they
+        are both following horse races at the site.","shortDescription":"A gambler
+        collapses in front of House while they are both following horse races at the
+        site.","episodeNum":9,"seasonNum":2,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590033","rootId":"3056225","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Failure
+        to Communicate","releaseYear":2006,"releaseDate":"2006-01-10","origAirDate":"2006-01-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"With
+        House and Stacy out of town, the team is left on its own to help a journalist,
+        whose sudden collapse is followed by an inability to speak clearly.","shortDescription":"On
+        its own, the team must help a journalist who suddenly collapses.","episodeNum":10,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Jace Alexander"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590034","rootId":"3056226","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Need
+        to Know","releaseYear":2006,"releaseDate":"2006-02-07","origAirDate":"2006-02-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        housewife (Julie Warner) on fertility medication visits Princeton Plainsboro
+        Hospital when her inexplicable muscle-flailing causes her to crash her car.","shortDescription":"Woman''s
+        inexplicable muscle-flailing causes her to crash a car.","episodeNum":11,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Semel","Pamela Davis"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590035","rootId":"3056227","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Distractions","releaseYear":2006,"releaseDate":"2006-02-14","origAirDate":"2006-02-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a young man comes into the hospital severely burned and has unusual blood-test
+        results, House and his team have a difficult challenge.","shortDescription":"A
+        young man comes into the hospital severely burned and has unusual blood-test
+        results.","episodeNum":12,"seasonNum":2,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Dan Attias"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590036","rootId":"3056228","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Skin
+        Deep","releaseYear":2006,"releaseDate":"2006-02-20","origAirDate":"2006-02-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a supermodel for heroin addiction, Dr. House uncovers a startling
+        secret; Wilson hopes that House''s increased leg pain is proof that his nerves
+        are regenerating.","shortDescription":"While treating a supermodel for heroin
+        addiction, Dr. House uncovers a startling secret.","episodeNum":13,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["James Hayman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590037","rootId":"3056229","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Sex
+        Kills","releaseYear":2006,"releaseDate":"2006-03-07","origAirDate":"2006-03-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        believes a patient''s (Howard Hesseman) seizure was caused by an infection,
+        but the man''s sudden heart attack forces the team to change direction and
+        opt for a heart transplant.","shortDescription":"A seizure patient''s heart
+        attack prompts the team to consider a transplant.","episodeNum":14,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Semel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590038","rootId":"3056230","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Clueless","releaseYear":2006,"releaseDate":"2006-03-28","origAirDate":"2006-03-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man suffers from a breathing attack while role-playing in the bedroom with
+        his wife.","shortDescription":"A man suffers from a breathing attack while
+        role-playing in the bedroom with his wife.","episodeNum":15,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590039","rootId":"3056231","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Safe","releaseYear":2006,"releaseDate":"2006-04-04","origAirDate":"2006-04-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young heart-transplant patient has a severe allergic reaction and goes into
+        shock despite living in a \"clean\" room.","shortDescription":"A patient has
+        a severe allergic reaction despite living in a \"clean\" room.","episodeNum":16,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Felix Alcala"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590040","rootId":"3056232","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"All
+        In","releaseYear":2006,"releaseDate":"2006-04-11","origAirDate":"2006-04-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        tries to save the life of a young boy who has the same unique symptoms as
+        an elderly patient who died.","shortDescription":"A young boy who has the
+        same unique symptoms as a patient who died.","episodeNum":17,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Fred Gerber"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590041","rootId":"3056233","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Sleeping
+        Dogs Lie","releaseYear":2006,"releaseDate":"2006-04-18","origAirDate":"2006-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        relationship between a liver donor and the intended recipient throws the team
+        into an ethical quandary.","shortDescription":"A donor-recipient relationship
+        throws the team into an ethical quandary.","episodeNum":18,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590042","rootId":"3056234","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House
+        vs. God","releaseYear":2006,"releaseDate":"2006-04-25","origAirDate":"2006-04-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        takes on a teenage faith healer; tension brews between Cameron and Foreman.","shortDescription":"House
+        takes on a teenage faith healer; tension brews between Cameron and Foreman.","episodeNum":19,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["John F. Showalter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590043","rootId":"3056235","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Euphoria,
+        Part 1","releaseYear":2006,"releaseDate":"2006-05-02","origAirDate":"2006-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":1,"totalParts":2},"longDescription":"A
+        police officer in critical condition has bizarre symptoms; Dr. Foreman finds
+        himself in an unpleasant situation.","shortDescription":"A cop in critical
+        condition has odd symptoms; Dr. Foreman finds himself in an unpleasant situation.","episodeNum":20,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590044","rootId":"3056236","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Euphoria,
+        Part 2","releaseYear":2006,"releaseDate":"2006-05-02","origAirDate":"2006-05-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":2,"totalParts":2},"longDescription":"Facing
+        imminent death, Dr. Foreman talks with his father and tries to make amends;
+        House tries radical procedures to save Foreman''s life.","shortDescription":"Facing
+        imminent death, Dr. Foreman talks with his father and tries to make amends.","episodeNum":21,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590045","rootId":"3056237","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Forever","releaseYear":2006,"releaseDate":"2006-05-09","origAirDate":"2006-05-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team try to save the lives of a young mother and her newborn son;
+        Foreman struggles to regain normalcy in his life.","shortDescription":"House
+        and the team try to save the lives of a young mother and her newborn son.","episodeNum":22,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590046","rootId":"3056238","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Who''s
+        Your Daddy?","releaseYear":2006,"releaseDate":"2006-05-16","origAirDate":"2006-05-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House''s
+        former bandmate, Crandall, brings in a teenage girl who is having hallucinations
+        about Hurricane Katrina; Cuddy looks for a sperm donor.","shortDescription":"House''s
+        former bandmate brings in a hallucinating girl; Cuddy looks for a sperm donor.","episodeNum":23,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Martha Mitchell"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590047","rootId":"3056239","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"No
+        Reason","releaseYear":2006,"releaseDate":"2006-05-23","origAirDate":"2006-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        disgruntled former patient (Elias Koteas) walks into House''s office and shoots
+        him while House and his team are trying to help a man with a swollen tongue.","shortDescription":"A
+        disgruntled former patient walks into House''s office and shoots him.","episodeNum":24,"seasonNum":2,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Shore"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892175_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590048","rootId":"3056240","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Meaning","releaseYear":2006,"releaseDate":"2006-09-05","origAirDate":"2006-09-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        returns to work after healing from gunshot wounds; a paraplegic man drives
+        into a swimming pool; a young woman finds herself paralyzed after a yoga session.","shortDescription":"House
+        returns to work after healing from gunshot wounds to two cases involving paralysis.","episodeNum":1,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590049","rootId":"3056241","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Cane
+        & Able","releaseYear":2006,"releaseDate":"2006-09-12","origAirDate":"2006-09-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        denies his physical pain; a child comes to the hospital with rectal bleeding
+        and proclamations of being tortured by aliens.","shortDescription":"House
+        denies his physical pain; a child has claims of being tortured by aliens.","episodeNum":2,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590050","rootId":"3056242","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Informed
+        Consent","releaseYear":2006,"releaseDate":"2006-09-17","origAirDate":"2006-09-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and team wrestle with an ethical dilemma when a patient asks them to help
+        him end his life.","shortDescription":"House and team wrestle with an ethical
+        dilemma when a patient asks them to help him end his life.","episodeNum":3,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Laura Innes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590051","rootId":"3056243","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Lines
+        in the Sand","releaseYear":2006,"releaseDate":"2006-09-26","origAirDate":"2006-09-26","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        House takes the case of an autistic 10-year-old who screams for no apparent
+        reason, then House refuses to use his office after Cuddy makes a minor change.","shortDescription":"House
+        takes the case of an autistic 10-year-old who screams for no reason.","episodeNum":4,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Newton Thomas Sigel"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"MA
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590052","rootId":"3056244","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fools
+        for Love","releaseYear":2006,"releaseDate":"2006-10-31","origAirDate":"2006-10-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        treats a young married couple with similar symptoms, but they are shocked
+        by the cause of the illness; a walk-in patient (David Morse) stands up to
+        House.","shortDescription":"House treats a young married couple with similar
+        symptoms, but they are shocked by the cause.","episodeNum":5,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590053","rootId":"3056245","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Que
+        Sera Sera","releaseYear":2006,"releaseDate":"2006-11-07","origAirDate":"2006-11-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        being found in a coma at his apartment, a 600-pound man is admitted to the
+        hospital; House spends the night in jail after being arrested for a number
+        of violations.","shortDescription":"After being found in a coma at his apartment,
+        a 600-pound man is admitted to the hospital.","episodeNum":6,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590054","rootId":"3056246","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Son
+        of Coma Guy","releaseYear":2006,"releaseDate":"2006-11-14","origAirDate":"2006-11-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Symptoms
+        point to a possible genetic connection when House notices something about
+        the son of a man (John Larroquette) who has been in a coma for a decade; Wilson
+        confronts House about stealing his prescription pad.","shortDescription":"House
+        notices something about the son of a man who has been in a coma for a decade.","episodeNum":7,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590055","rootId":"3056247","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Whac-A-Mole","releaseYear":2006,"releaseDate":"2006-11-21","origAirDate":"2006-11-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        challenges his co-workers to correctly diagnose the ailment of an 18-year-old
+        heart-attack patient (Patrick Fugit).","shortDescription":"House challenges
+        his co-workers to correctly diagnose an ailment.","episodeNum":8,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590056","rootId":"3056248","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Finding
+        Judas","releaseYear":2006,"releaseDate":"2006-11-28","origAirDate":"2006-11-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        takes the divorced parents of a young patient to court when their bickering
+        prevents a decision on her treatment.","shortDescription":"House takes the
+        parents of a young patient to court when their bickering impedes treatment.","episodeNum":9,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590057","rootId":"3056249","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Merry
+        Little Christmas","releaseYear":2006,"releaseDate":"2006-12-12","origAirDate":"2006-12-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"House
+        is furious about Wilson striking a deal with Tritter, and at the same time,
+        he tries to diagnose a little person''s serious illness.","shortDescription":"House
+        is furious with Wilson; he tries to diagnose a little person''s serious illness.","episodeNum":10,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Tony To","Liz Friedman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Christmas","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590059","rootId":"3056251","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Words
+        and Deeds","releaseYear":2007,"releaseDate":"2007-01-09","origAirDate":"2007-01-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        makes a shocking revelation in a bid to save himself from jail time; a firefighter
+        chooses to have a risky, radical treatment on his brain in order to keep a
+        secret.","shortDescription":"House makes a shocking revelation in a bid to
+        save himself from jail time.","episodeNum":11,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590060","rootId":"3056252","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"One
+        Day, One Room","releaseYear":2007,"releaseDate":"2007-01-30","origAirDate":"2007-01-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        returns to the hospital after a short stint in rehab; Cuddy comes to collect
+        on the debt of perjuring herself for House; House encounters a patient who
+        tests positive for an STD and says she was raped recently.","shortDescription":"House
+        returns to the hospital after a short stint in rehab; a young rape victim
+        comes in.","episodeNum":12,"seasonNum":3,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590061","rootId":"3056253","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Needle
+        in a Haystack","releaseYear":2007,"releaseDate":"2007-02-06","origAirDate":"2007-02-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        16-year-old patient has internal bleeding, but his Gypsy parents arrive and
+        refuse all modern medical treatment.","shortDescription":"A teen patient has
+        internal bleeding, but his parents refuse all modern medical treatment.","episodeNum":13,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Peter O''Fallon"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H43M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590062","rootId":"3056254","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Insensitive","releaseYear":2007,"releaseDate":"2007-02-13","origAirDate":"2007-02-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        snowstorm leaves the ER short-staffed on Valentine''s Day; House determines
+        that Foreman''s patient, who was injured in a car accident, has a rare condition
+        that makes her completely insensitive to pain.","shortDescription":"House
+        determines that a patient has a rare condition that makes her completely insensitive
+        to pain.","episodeNum":14,"seasonNum":3,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590063","rootId":"3056255","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Half-Wit","releaseYear":2007,"releaseDate":"2007-03-06","origAirDate":"2007-03-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        35-year-old musical savant (Dave Matthews) is admitted to the hospital with
+        a rare movement disorder; Cameron discovers that House has been in contact
+        with a Massachusetts hospital.","shortDescription":"A 35-year-old musical
+        savant is admitted to the hospital with a rare movement disorder.","episodeNum":15,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590064","rootId":"3056256","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Top
+        Secret","releaseYear":2007,"releaseDate":"2007-03-27","origAirDate":"2007-03-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House''s
+        newest patient, an ex-Marine who had saved House''s life in a dream the night
+        before, intrigues him.","shortDescription":"House''s newest patient saved
+        his life in a dream the night before.","episodeNum":16,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590065","rootId":"3056257","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fetal
+        Position","releaseYear":2007,"releaseDate":"2007-04-03","origAirDate":"2007-04-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        pregnant photographer collapses in the midst of a photo shoot with a famous
+        musician (Tyson Ritter); Foreman and Cuddy learn about Cameron and Chase''s
+        secret relationship.","shortDescription":"A pregnant photographer collapses
+        during a photo shoot with a famous musician.","episodeNum":17,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590066","rootId":"3056258","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Airborne","releaseYear":2007,"releaseDate":"2007-04-10","origAirDate":"2007-04-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a man next to House on a flight from Singapore to the United States becomes
+        violently ill, Cuddy suspects he has a deadly contagious virus.","shortDescription":"Cuddy
+        suspects an airplane passenger has a deadly contagious virus.","episodeNum":18,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Elodie Keene"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590067","rootId":"3056259","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Act
+        Your Age","releaseYear":2007,"releaseDate":"2007-04-17","origAirDate":"2007-04-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a 6-year-old girl collapses at day care, the team discovers that she has a
+        condition that is common in much older patients; tension develops between
+        Cameron and Chase.","shortDescription":"A 6-year-old girl collapses at day
+        care; tension develops between Cameron and Chase.","episodeNum":19,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590139","rootId":"3344957","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590068","rootId":"3056260","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House
+        Training","releaseYear":2007,"releaseDate":"2007-04-24","origAirDate":"2007-04-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a young scam artist passes out while working a card-playing scheme, Foreman
+        suspects her condition stems from drug abuse; Cuddy and Wilson go on a date
+        to an art exhibit.","shortDescription":"A young scam artist passes out while
+        working a card-playing scheme.","episodeNum":20,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Paul McCrane"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590141","rootId":"3344959","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-04-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590069","rootId":"3056261","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Family","releaseYear":2007,"releaseDate":"2007-05-01","origAirDate":"2007-05-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Wilson
+        prepares a 14-year-old leukemia patient for a last-resort bone-marrow transplant
+        from his younger brother; a mistake that killed a patient a week earlier haunts
+        Foreman.","shortDescription":"Wilson prepares a 14-year-old leukemia patient
+        for a bone-marrow transplant.","episodeNum":21,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590142","rootId":"3344960","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590070","rootId":"3056262","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Resignation","releaseYear":2007,"releaseDate":"2007-05-08","origAirDate":"2007-05-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        19-year-old college student goes to the hospital after coughing up blood during
+        karate class; House takes a special interest in an attractive nutritionist
+        (Piper Perabo), who accompanied her boyfriend to the clinic.","shortDescription":"House
+        takes a special interest in an attractive nutritionist.","episodeNum":22,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Martha Mitchell"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590071","rootId":"3056263","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Jerk","releaseYear":2007,"releaseDate":"2007-05-15","origAirDate":"2007-05-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        16-year-old chess prodigy with intense head pain and behavioral issues offends
+        the members of House''s team during his treatment.","shortDescription":"A
+        16-year-old chess prodigy offends the members of House''s team.","episodeNum":23,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Daniel Sackheim"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590143","rootId":"3344961","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590144","rootId":"3344962","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590072","rootId":"3056264","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Human
+        Error","releaseYear":2007,"releaseDate":"2007-05-29","origAirDate":"2007-05-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team takes on the case of a woman who was rescued at sea en route from Cuba
+        in her desperate bid to get a diagnosis from Dr. House.","shortDescription":"A
+        woman escapes from Cuba in order to get a diagnosis from House.","episodeNum":24,"seasonNum":3,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"MA 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892176_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590145","rootId":"3344963","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-05-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590146","rootId":"3344964","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590147","rootId":"3344965","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590148","rootId":"3344966","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590149","rootId":"3344967","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-06-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590150","rootId":"3344968","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590151","rootId":"3344969","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}]}'
+  recorded_at: Sun, 27 Sep 2020 20:11:13 GMT
+- request:
+    method: get
+    uri: https://data.tmsapi.com/v1.1/series/185044/episodes?api_key=<TMS_API_KEY>&offset=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7159
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:10:33 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1b-26.mashery.com
+      Content-Length:
+      - '8463'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hitCount":267,"hits" :  [{"tmsId":"EP006883590152","rootId":"3344970","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590153","rootId":"3344971","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590154","rootId":"3344972","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-07-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590155","rootId":"3344973","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590156","rootId":"3344974","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590157","rootId":"3344975","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590158","rootId":"3344976","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590159","rootId":"3344977","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590160","rootId":"3344978","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590161","rootId":"3344979","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-08-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590162","rootId":"3344980","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590163","rootId":"3344981","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590164","rootId":"3344982","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590165","rootId":"3344983","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-09-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590073","rootId":"3056265","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Alone","releaseYear":2007,"releaseDate":"2007-09-25","origAirDate":"2007-09-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young woman survives an office-building collapse, and House discusses his
+        ideas about the case with a hospital janitor; Wilson resorts to desperate
+        measures.","shortDescription":"A young woman survives a building collapse,
+        and House discusses the case with a hospital janitor.","episodeNum":1,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590166","rootId":"3344984","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590074","rootId":"3056266","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Right Stuff","releaseYear":2007,"releaseDate":"2007-10-02","origAirDate":"2007-10-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        begins interviewing for the open positions on his team and sets the applicants
+        against one another to help treat a woman who has an unusual neurological
+        disorder.","shortDescription":"House begins interviewing for the open positions
+        on his team.","episodeNum":2,"seasonNum":4,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590167","rootId":"3344985","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590075","rootId":"3056267","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"97
+        Seconds","releaseYear":2007,"releaseDate":"2007-10-09","origAirDate":"2007-10-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        splits the final 10 fellowship candidates into two teams by gender; the teams
+        must treat a man with muscular atrophy and diagnose the cause; at his new
+        hospital, Foreman resorts to Houselike behavior to help a patient.","shortDescription":"House
+        splits the final 10 fellowship candidates into two teams by gender.","episodeNum":3,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590168","rootId":"3344986","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590169","rootId":"3344987","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590076","rootId":"3056268","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Guardian
+        Angels","releaseYear":2007,"releaseDate":"2007-10-23","origAirDate":"2007-10-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the remaining candidates must determine why a 20-year-old cosmetician
+        had a massive seizure and now has hallucinations; Foreman''s reputation precedes
+        him as he interviews for a new job; House must narrow the candidates to six.","shortDescription":"The
+        candidates must determine why a cosmetician hallucinates.","episodeNum":4,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Conseil Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590170","rootId":"3344988","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-10-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590077","rootId":"3056269","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Mirror
+        Mirror","releaseYear":2007,"releaseDate":"2007-10-30","origAirDate":"2007-10-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a patient they think is a hypochondriac, Foreman and the six fellows
+        seem to learn more about themselves than about the patient; Cameron and Chase
+        gamble on which candidate House will cut next.","shortDescription":"Foreman
+        and the fellows treat a patient they think is a hypochondriac.","episodeNum":5,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590171","rootId":"3344989","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-11-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590078","rootId":"3056270","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Whatever
+        It Takes","releaseYear":2007,"releaseDate":"2007-11-06","origAirDate":"2007-11-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        CIA recruits House to help an agent dying of an unknown illness; Foreman faces
+        resistance from the remaining fellowship candidates when they question his
+        judgment.","shortDescription":"The CIA recruits House to help an agent; the
+        fellowship candidates question Foreman''s judgment.","episodeNum":6,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590172","rootId":"3344990","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-11-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590079","rootId":"3056271","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Ugly","releaseYear":2007,"releaseDate":"2007-11-13","origAirDate":"2007-11-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        documentary film crew follows House and his team, as they treat a teenager
+        who had a heart attack prior to facial reconstruction; several of the fellowship
+        candidates distract House.","shortDescription":"A documentary film crew follows
+        House and his team, as they treat a teenager who had a heart attack.","episodeNum":7,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590173","rootId":"3344991","seriesId":"185044","subType":"Series","title":"House","releaseYear":2007,"releaseDate":"2007","origAirDate":"2007-11-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590080","rootId":"3056272","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"You
+        Don''t Want to Know","releaseYear":2007,"releaseDate":"2007-11-20","origAirDate":"2007-11-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        a magician''s heart fails during an underwater escape act, House suspects
+        him of being a scam artist faking his ailments.","shortDescription":"House
+        encounters a magician whose heart failed during an act.","episodeNum":8,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Lesli Linka Glatter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590081","rootId":"3056273","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Games","releaseYear":2007,"releaseDate":"2007-11-27","origAirDate":"2007-11-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        assigns the candidates to the particularly challenging case of an uncooperative,
+        over-the-hill rock star with a history of drug abuse and civil disobedience;
+        Cuddy orders House to hire the members of his team.","shortDescription":"House
+        assigns the candidates to the case of an over-the-hill rock star.","episodeNum":9,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590175","rootId":"3344993","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-01-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590174","rootId":"3344992","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-01-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590176","rootId":"3344994","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-01-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590083","rootId":"3056275","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"It''s
+        a Wonderful Lie","releaseYear":2008,"releaseDate":"2008-01-28","origAirDate":"2008-01-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"As
+        the team runs tests to determine what caused a woman to have sudden paralysis
+        of the hands, the rest of her system begins to shut down; the team participates
+        in a gift exchange with a twist, courtesy of House.","shortDescription":"The
+        team runs tests to determine what caused a woman to experience sudden paralysis
+        of the hands.","episodeNum":10,"seasonNum":4,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Christmas","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590082","rootId":"3056274","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Frozen","releaseYear":2008,"releaseDate":"2008-02-03","origAirDate":"2008-02-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team must treat, by way of webcam, a psychiatrist (Mira Sorvino) who
+        is stationed at the South Pole; the identity of Wilson''s love interest surprises
+        House.","shortDescription":"House and his team must treat a psychiatrist in
+        Antarctica by way of webcam.","episodeNum":11,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590177","rootId":"3344995","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590084","rootId":"3056276","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Don''t
+        Ever Change","releaseYear":2008,"releaseDate":"2008-02-05","origAirDate":"2008-02-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team consider foul play while treating a woman who collapsed at her
+        wedding; Wilson''s newly revealed relationship preoccupies House.","shortDescription":"House
+        and the team treat a woman who collapsed at her wedding.","episodeNum":12,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590178","rootId":"3344996","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590179","rootId":"3344997","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590180","rootId":"3344998","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-02-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590181","rootId":"3344999","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590182","rootId":"3345000","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590183","rootId":"3345001","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590184","rootId":"3345002","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590185","rootId":"3345003","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-03-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590186","rootId":"3345004","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590187","rootId":"3345005","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590188","rootId":"3345006","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590085","rootId":"3056277","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"No
+        More Mr. Nice Guy","releaseYear":2008,"releaseDate":"2008-04-28","origAirDate":"2008-04-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        suspects a patient has a bigger problem than the original diagnosis; House
+        and Amber argue about how much time they each get to spend with Wilson; Cuddy
+        demands that House give his team performance reviews.","shortDescription":"House
+        suspects a patient has a bigger problem than what he was originally diagnosed
+        with.","episodeNum":13,"seasonNum":4,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590189","rootId":"3345007","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-04-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590086","rootId":"3056278","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Living
+        the Dream","releaseYear":2008,"releaseDate":"2008-05-05","origAirDate":"2008-05-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        takes matters into his own hands when he feels certain that one of the actors
+        on his favorite soap opera (Jason Lewis) is suffering from a serious medical
+        condition, but the actor dismisses House''s assessment.","shortDescription":"House
+        is sure one of the actors on his favorite soap opera has a serious medical
+        condition.","episodeNum":14,"seasonNum":4,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590087","rootId":"3056279","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House''s
+        Head","releaseYear":2008,"releaseDate":"2008-05-12","origAirDate":"2008-05-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":1,"totalParts":2},"longDescription":"A
+        bus accident robs House of several hours, and as his memory slowly returns,
+        he realizes that one of his fellow passengers was exhibiting signs of a deadly
+        illness, so he races to unlock the secrets in his brain.","shortDescription":"After
+        a bus accident House realizes one of the passengers was exhibiting signs of
+        a deadly illness.","episodeNum":15,"seasonNum":4,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590088","rootId":"3056280","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Wilson''s
+        Heart","releaseYear":2008,"releaseDate":"2008-05-19","origAirDate":"2008-05-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":2,"totalParts":2},"longDescription":"House''s
+        murky memories of the bus crash test his friendship with Wilson and threaten
+        to change their lives forever.","shortDescription":"House''s murky memories
+        of the bus crash test his friendship with Wilson.","episodeNum":16,"seasonNum":4,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892177_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590191","rootId":"3345009","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590190","rootId":"3345008","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590192","rootId":"3345010","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590090","rootId":"3056282","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Dying
+        Changes Everything","releaseYear":2008,"releaseDate":"2008-09-14","origAirDate":"2008-09-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Still
+        mourning the death of his girlfriend, Wilson resigns from Princeton Plainsboro;
+        House must determine if he is responsible for the death of his best friend''s
+        girlfriend; Thirteen struggles to treat a patient objectively.","shortDescription":"Still
+        mourning the death of his girlfriend, Wilson resigns from Princeton Plainsboro.","episodeNum":1,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590193","rootId":"3345011","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","ratings":[{"body":"Canadian
+        Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590091","rootId":"3056283","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Not
+        Cancer","releaseYear":2008,"releaseDate":"2008-09-23","origAirDate":"2008-09-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team investigate a string of deaths centering around a single organ
+        donor, then rush to save the only two surviving recipients; House auditions
+        new best friends and uses a detective to spy on Wilson.","shortDescription":"House
+        and the team investigate a string of deaths centering around a single organ
+        donor.","episodeNum":2,"seasonNum":5,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590194","rootId":"3345012","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-09-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590092","rootId":"3056284","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Adverse
+        Events","releaseYear":2008,"releaseDate":"2008-09-30","origAirDate":"2008-09-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team take on the case of a struggling artist with an undiagnosed illness
+        that''s distorting his perception and threatening his career; House continues
+        to have a private investigator dig up dirt on everyone on his team.","shortDescription":"House
+        and the team take on the case of a struggling artist with an undiagnosed illness.","episodeNum":3,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590195","rootId":"3345013","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590196","rootId":"3345014","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590093","rootId":"3056285","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Birthmarks","releaseYear":2008,"releaseDate":"2008-10-14","origAirDate":"2008-10-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        receiving word that his father has passed away, House is coerced into attending
+        the funeral; the team tries to diagnose the illness of a woman who was in
+        China searching for her birth mother.","shortDescription":"House attends a
+        funeral; the team tries to diagnose the illness of a woman who was in China.","episodeNum":4,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590197","rootId":"3345015","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","ratings":[{"body":"Canadian
+        Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590094","rootId":"3056286","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Lucky
+        Thirteen","releaseYear":2008,"releaseDate":"2008-10-21","origAirDate":"2008-10-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Thirteen''s
+        date gets ill after a night of partying, and House takes on her case; Foreman
+        confronts Thirteen about her self-destructive lifestyle; private investigator
+        Lucas is hot on Wilson''s trail.","shortDescription":"Thirteen''s date falls
+        ill after a night of partying, and House takes on her case.","episodeNum":5,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590198","rootId":"3345016","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-10-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"ratings":[{"body":"Canadian
+        Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590095","rootId":"3056287","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Joy","releaseYear":2008,"releaseDate":"2008-10-28","origAirDate":"2008-10-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team takes on the case of a sleepwalking patient experiencing unexplained
+        blackouts; House discovers that Cuddy is planning to adopt a baby that is
+        due in two weeks.","shortDescription":"The team treats a sleepwalking patient
+        experiencing unexplained blackouts.","episodeNum":6,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590199","rootId":"3345017","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590200","rootId":"3345018","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590096","rootId":"3056288","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Itch","releaseYear":2008,"releaseDate":"2008-11-11","origAirDate":"2008-11-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat an agoraphobic who adamantly refuses to leave his home
+        and get treatment at the hospital; Chase and Cameron try to work through some
+        kinks in their relationship; House deals with an itch he can''t seem to scratch.","shortDescription":"House
+        and the team treat an agoraphobic who adamantly refuses to leave his home.","episodeNum":7,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590201","rootId":"3345019","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590097","rootId":"3056289","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Emancipation","releaseYear":2008,"releaseDate":"2008-11-18","origAirDate":"2008-11-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        emancipated minor (Emily Rios) working as a factory manager falls ill on the
+        job; Foreman takes on a pediatric case that has him questioning whether he
+        can function without House''s oversight.","shortDescription":"An emancipated
+        minor working as a factory manager falls ill on the job.","episodeNum":8,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Jim Hayman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590202","rootId":"3345020","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-11-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590098","rootId":"3056290","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Last
+        Resort","releaseYear":2008,"releaseDate":"2008-11-25","origAirDate":"2008-11-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man (Zeljko Ivanek) willing to kill or die for a diagnosis takes House, Thirteen
+        and a number of patients hostage in Cuddy''s office, where House tries to
+        come up with the correct diagnosis.","shortDescription":"A man willing to
+        kill or die for a diagnosis takes House and several patients hostage.","episodeNum":9,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H51M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590203","rootId":"3345021","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-12-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590099","rootId":"3056291","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Let
+        Them Eat Cake","releaseYear":2008,"releaseDate":"2008-12-02","origAirDate":"2008-12-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a high-profile fitness trainer who collapses while shooting
+        an infomercial; Thirteen participates in a clinical trial led by Foreman.","shortDescription":"A
+        high-profile fitness trainer collapses while shooting an infomercial.","episodeNum":10,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590100","rootId":"3056292","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Joy
+        to the World","releaseYear":2008,"releaseDate":"2008-12-09","origAirDate":"2008-12-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"House
+        and the team treat a teenager who collapsed during her high-school Christmas
+        program; Foreman and Thirteen''s relationship progresses; Cuddy receives an
+        unexpected gift.","shortDescription":"Foreman and Thirteen''s relationship
+        progresses; unexpected gift.","episodeNum":11,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Christmas","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590204","rootId":"3345022","seriesId":"185044","subType":"Series","title":"House","releaseYear":2008,"releaseDate":"2008","origAirDate":"2008-12-29","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590205","rootId":"3345023","seriesId":"185044","subType":"Series","title":"House","releaseYear":2009,"releaseDate":"2009","origAirDate":"2009-01-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590206","rootId":"3345024","seriesId":"185044","subType":"Series","title":"House","releaseYear":2009,"releaseDate":"2009","origAirDate":"2009-01-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590101","rootId":"3056293","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Painless","releaseYear":2009,"releaseDate":"2009-01-19","origAirDate":"2009-01-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team try to diagnose a man''s severe, chronic pain; Thirteen and Foreman
+        explore their complicated relationship; Cuddy discovers that caring for her
+        baby leaves her with little time to run the hospital.","shortDescription":"House
+        and the team try to diagnose a man''s severe, chronic pain.","episodeNum":12,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590207","rootId":"3345025","seriesId":"185044","subType":"Series","title":"House","releaseYear":2009,"releaseDate":"2009","origAirDate":"2009-01-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Prickly
+        genius Dr. Gregory House tackles health mysteries with his team of young diagnosticians;
+        flawless instincts and unconventional thinking help earn him great respect,
+        despite his brutal honesty and antisocial tendencies.","shortDescription":"A
+        brilliant and acerbic diagnostician leads a team of specialists.","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590102","rootId":"3056294","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Big
+        Baby","releaseYear":2009,"releaseDate":"2009-01-26","origAirDate":"2009-01-26","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Cuddy
+        gives some of her day-to-day responsibilities to Cameron; the team takes on
+        the case of a teacher who collapsed after spitting up blood during a class.","shortDescription":"The
+        team takes on the case of a teacher who collapsed after spitting up blood
+        during a class.","episodeNum":13,"seasonNum":5,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590103","rootId":"3056295","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Greater Good","releaseYear":2009,"releaseDate":"2009-02-02","origAirDate":"2009-02-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a former cancer researcher who gave up her career to pursue her own
+        personal happiness, House and his staff begin to question their own choices;
+        Thirteen begins to show serious reactions to her experimental treatment.","shortDescription":"House
+        and his staff begin to question their life choices while treating a former
+        cancer researcher.","episodeNum":14,"seasonNum":5,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Lesli Linka Glatter"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590104","rootId":"3056296","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Unfaithful","releaseYear":2009,"releaseDate":"2009-02-16","origAirDate":"2009-02-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        priest is admitted to the ER after he sees a bleeding Jesus hovering at his
+        doorstep; House confronts Thirteen and Foreman about their relationship.","shortDescription":"A
+        priest is admitted to the ER after he sees a bleeding Jesus hovering at his
+        doorstep.","episodeNum":15,"seasonNum":5,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590105","rootId":"3056297","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Softer Side","releaseYear":2009,"releaseDate":"2009-02-23","origAirDate":"2009-02-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a teenager who doesn''t know that he has genetic mosaicism; Wilson
+        and Cuddy think something is wrong with House when he starts acting nice.","shortDescription":"The
+        team treats a teenager who doesn''t know that he has genetic mosaicism.","episodeNum":16,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Deran Sarafian"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590106","rootId":"3056298","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Social Contract","releaseYear":2009,"releaseDate":"2009-03-09","origAirDate":"2009-03-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a patient who speaks his mind uncontrollably; House thinks
+        Taub and Wilson are keeping something from him.","shortDescription":"House
+        and the team treat a patient who speaks his mind uncontrollably.","episodeNum":17,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590107","rootId":"3056299","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Here
+        Kitty","releaseYear":2009,"releaseDate":"2009-03-16","origAirDate":"2009-03-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        sets out to disprove the allegations of a nursing home worker who feigns illness
+        after being visited by the facility''s pet cat, which has a reputation for
+        visiting people who are about to die.","shortDescription":"House sets out
+        to disprove the allegations of a nursing home worker who feigns illness.","episodeNum":18,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590108","rootId":"3056300","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Locked
+        In","releaseYear":2009,"releaseDate":"2009-03-30","origAirDate":"2009-03-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man (Mos Def) awakes in a New York hospital after a bicycle accident, unable
+        to move or communicate; injured and in the next bed, Dr. House insists he
+        knows what is affecting the man and has him transferred to Princeton Plainsboro.","shortDescription":"A
+        man awakes in a New York hospital after a bicycle accident, unable to move
+        or communicate.","episodeNum":19,"seasonNum":5,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590109","rootId":"3056301","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Simple
+        Explanation","releaseYear":2009,"releaseDate":"2009-04-06","origAirDate":"2009-04-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        caring for her dying husband (Meat Loaf Aday) for several months, a woman
+        (Colleen Camp) collapses and, while his condition mysteriously improves, hers
+        deteriorates.","shortDescription":"After spending the last several months
+        caring for her dying husband, a woman collapses.","episodeNum":20,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590111","rootId":"3504211","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Saviors","releaseYear":2009,"releaseDate":"2009-04-13","origAirDate":"2009-04-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Cameron
+        asks House to accept the case of an environmental activist who collapsed at
+        a protest with mysterious symptoms.","shortDescription":"Cameron asks House
+        to accept the case of an environmental activist who collapsed at a protest.","episodeNum":21,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Matthew Penn"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590112","rootId":"3518819","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"House
+        Divided","releaseYear":2009,"releaseDate":"2009-04-27","origAirDate":"2009-04-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a deaf 14-year-old who collapses while competing in a wrestling
+        match; House has trouble sleeping.","shortDescription":"A deaf 14-year-old
+        collapses while competing in a wrestling match.","episodeNum":22,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590113","rootId":"3522055","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Under
+        My Skin","releaseYear":2009,"releaseDate":"2009-05-04","origAirDate":"2009-05-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a ballerina whose lungs collapse during a performance;
+        House is desperate to find a cure for his insomnia.","shortDescription":"House
+        and the team treat a ballerina whose lungs collapse during a performance.","episodeNum":23,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590114","rootId":"3522067","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Both
+        Sides Now","releaseYear":2009,"releaseDate":"2009-05-11","origAirDate":"2009-05-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        is intrigued by a patient whose left brain and right brain operate independently,
+        creating two distinct personalities.","shortDescription":"House treats a patient
+        whose left brain and right brain operate independently.","episodeNum":24,"seasonNum":5,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892178_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590221","rootId":"8179948","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Broken,
+        Part 2","releaseYear":2009,"releaseDate":"2009-09-21","origAirDate":"2009-09-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":2,"totalParts":2},"longDescription":"House
+        decides to accept treatment from Dr. Nolan in order to get his license reinstated.","shortDescription":"House
+        decides to accept treatment from Dr. Nolan in order to get his license reinstated.","episodeNum":2,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TVPG"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H46M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590220","rootId":"8179943","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Broken,
+        Part 1","releaseYear":2009,"releaseDate":"2009-09-21","origAirDate":"2009-09-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"partNum":{"part":1,"totalParts":2},"longDescription":"House
+        goes through detox, hoping to stop the hallucinations that tormented him;
+        Dr. Nolan refuses to sign the paperwork to reinstate House''s license until
+        House participates in his own mental recovery.","shortDescription":"House
+        goes through detox, hoping to stop the hallucinations that tormented him.","episodeNum":1,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Katie Jacobs"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590117","rootId":"7842531","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Epic
+        Fail","releaseYear":2009,"releaseDate":"2009-09-28","origAirDate":"2009-09-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        has surprising news for Cuddy; an ailing video game creator opts for treatments
+        suggested by people on the Internet rather than listening to the doctors;
+        Foreman tries to get House''s job.","shortDescription":"Ailing video game
+        creator opts for treatments suggested by people on the Internet.","episodeNum":3,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590118","rootId":"7849320","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Tyrant","releaseYear":2009,"releaseDate":"2009-10-05","origAirDate":"2009-10-05","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a controversial African politician (James Earl Jones) who has
+        fallen ill; Wilson tries to make amends with a feuding neighbor.","shortDescription":"The
+        team treats a controversial African politician who has fallen ill.","episodeNum":4,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}]}'
+  recorded_at: Sun, 27 Sep 2020 20:11:14 GMT
+- request:
+    method: get
+    uri: https://data.tmsapi.com/v1.1/series/185044/episodes?api_key=<TMS_API_KEY>&offset=200
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7160
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:10:35 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1c-35.mashery.com
+      Content-Length:
+      - '9667'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"hitCount":267,"hits" :  [{"tmsId":"EP006883590119","rootId":"7857554","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Instant
+        Karma","releaseYear":2009,"releaseDate":"2009-10-12","origAirDate":"2009-10-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        wealthy businessman brings his teenage son to the hospital and insists on
+        having House handle the case; Foreman and Chase prepare to present information
+        on the Dibala case.","shortDescription":"A wealthy businessman brings his
+        son to the hospital and insists on having House handle the case.","episodeNum":5,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590120","rootId":"7871176","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Brave
+        Heart","releaseYear":2009,"releaseDate":"2009-10-19","origAirDate":"2009-10-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team takes on the case of a police detective whose father, grandfather and
+        great-grandfather all died of sudden heart failure at age 40; House confronts
+        some of his ghosts.","shortDescription":"Police detective with a family history
+        of sudden heart failure.","episodeNum":6,"seasonNum":6,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590121","rootId":"7890233","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Known
+        Unknowns","releaseYear":2009,"releaseDate":"2009-11-09","origAirDate":"2009-11-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        teenage girl is brought to the hospital with severely swollen appendages after
+        a wild night out; as her condition worsens, the patient is unable to distinguish
+        fact from fiction; the doctors attend a medical conference.","shortDescription":"A
+        teenage girl is brought to the hospital with severely swollen appendages after
+        a wild night out.","episodeNum":7,"seasonNum":6,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Australian Classification
+        Board","code":"M 15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o,
+        T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590122","rootId":"7890261","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Teamwork","releaseYear":2009,"releaseDate":"2009-11-16","origAirDate":"2009-11-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        reclaims his role as head of diagnostics in time to treat an adult film star
+        admitted to the hospital for pulsating eye pain; Cuddy is reminded that Princeton
+        Plainsboro is not conducive to healthy personal relationships.","shortDescription":"House
+        treats an adult film star suffering from pulsating eye pain.","episodeNum":8,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590123","rootId":"7890277","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Ignorance
+        Is Bliss","releaseYear":2009,"releaseDate":"2009-11-23","origAirDate":"2009-11-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical","Holiday"],"longDescription":"On
+        the eve of Thanksgiving, the team treats an exceptionally brilliant physicist
+        who traded his career for a job as a courier; a myriad of strange symptoms
+        nearly stumps the doctors; the doctors wrestle with strained personal relationships.","shortDescription":"The
+        team treats an exceptionally brilliant physicist; strained relationships.","episodeNum":9,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","holiday":"Thanksgiving","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590125","rootId":"7923847","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Wilson","releaseYear":2009,"releaseDate":"2009-11-30","origAirDate":"2009-11-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        old friend and former patient of Wilson''s experiences paralysis in his right
+        arm; Cuddy continues her search for real estate.","shortDescription":"An old
+        friend and former patient of Wilson''s experiences paralysis in his right
+        arm.","episodeNum":10,"seasonNum":6,"topCast":["Hugh Laurie","Lisa Edelstein","Omar
+        Epps"],"directors":["Lesli Linka Glatter"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590126","rootId":"7972422","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Down Low","releaseYear":2010,"releaseDate":"2010-01-11","origAirDate":"2010-01-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        drug dealer mysteriously collapses during a sale; House and Wilson compete
+        for a new neighbor''s affection; Chase, Thirteen and Taub play a practical
+        joke.","shortDescription":"A drug dealer collapses during a sale; House and
+        Wilson compete for a neighbor''s affection.","episodeNum":11,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"ratings":[{"body":"USA Parental Rating","code":"TV14"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590127","rootId":"7993103","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Remorse","releaseYear":2010,"releaseDate":"2010-01-25","origAirDate":"2010-01-25","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        men on the team are charmed by an attractive female executive experiencing
+        random bouts of excruciating pain; House tries to make amends with a former
+        colleague.","shortDescription":"The men on the team are charmed by a female
+        executive experiencing random bouts of pain.","episodeNum":12,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590128","rootId":"7993340","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Moving
+        the Chains","releaseYear":2010,"releaseDate":"2010-02-01","origAirDate":"2010-02-01","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House''s
+        team rushes to treat an ailing college football star in time for the patient
+        to try out for the NFL; Foreman''s brother (Orlando Jones) makes a surprise
+        visit to the hospital.","shortDescription":"House''s team rushes to treat
+        an ailing college football star; Foreman''s brother visits.","episodeNum":13,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590129","rootId":"8000972","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"5
+        to 9","releaseYear":2010,"releaseDate":"2010-02-08","origAirDate":"2010-02-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        inner workings of the hospital are seen through the eyes of Dr. Cuddy.","shortDescription":"The
+        inner workings of the hospital are seen through the eyes of Dr. Cuddy.","episodeNum":14,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Andrew Bernstein"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590130","rootId":"8029262","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Private
+        Lives","releaseYear":2010,"releaseDate":"2010-03-08","origAirDate":"2010-03-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        avid blogger experiences sudden bruising and bleeding; Wilson and House discover
+        secrets about each other.","shortDescription":"A blogger experiences sudden
+        bruising and bleeding; secrets about Wilson and House are uncovered.","episodeNum":15,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590131","rootId":"8036994","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Black
+        Hole","releaseYear":2010,"releaseDate":"2010-03-15","origAirDate":"2010-03-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        high-school senior repeatedly hallucinates after blacking out during a class
+        trip; Wilson tries to furnish his condo.","shortDescription":"A high-school
+        senior repeatedly hallucinates after blacking out during a class trip.","episodeNum":16,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590132","rootId":"8073882","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Lockdown","releaseYear":2010,"releaseDate":"2010-04-12","origAirDate":"2010-04-12","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        hospital is locked down when a newborn disappears from the nursery; new insights
+        about the team''s personal lives, relationships and regrets surface.","shortDescription":"The
+        hospital is locked down when a newborn disappears from the nursery.","episodeNum":17,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Hugh Laurie"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590133","rootId":"8075289","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Knight
+        Fall","releaseYear":2010,"releaseDate":"2010-04-19","origAirDate":"2010-04-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a knight from a community of men and women living according
+        to the ideals of the High Renaissance; Wilson and an ex start over.","shortDescription":"Treating
+        a knight from a community of people living according to the ideals of the
+        High Renaissance.","episodeNum":18,"seasonNum":6,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590134","rootId":"8082610","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Open
+        and Shut","releaseYear":2010,"releaseDate":"2010-04-26","origAirDate":"2010-04-26","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        woman in an open marriage suddenly becomes ill during a date with her boyfriend;
+        House tests Wilson and Sam''s relationship.","shortDescription":"A woman in
+        an open marriage suddenly becomes ill during a date with her boyfriend.","episodeNum":19,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Conseil Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590135","rootId":"8084118","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Choice","releaseYear":2010,"releaseDate":"2010-05-03","origAirDate":"2010-05-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats an ailing groom; House, Chase and Foreman visit a karaoke bar
+        during a raucous night out.","shortDescription":"The team treats an ailing
+        groom; House, Chase and Foreman visit a karaoke bar.","episodeNum":20,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Juan Jos\u00e9 Campanella"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590136","rootId":"8096988","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Baggage","releaseYear":2010,"releaseDate":"2010-05-10","origAirDate":"2010-05-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        recounts the case of a woman who came to the emergency room with an unexplained
+        illness and no memory of her identity.","shortDescription":"A woman arrives
+        at the ER with an unexplained illness and no recollection of her identity.","episodeNum":21,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590137","rootId":"8097036","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Help
+        Me","releaseYear":2010,"releaseDate":"2010-05-17","origAirDate":"2010-05-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team heads outside the hospital to help provide medical attention at the scene
+        of an emergency.","shortDescription":"The team heads outside the hospital
+        to help provide medical attention at the scene of an emergency.","episodeNum":22,"seasonNum":6,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p7892179_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590223","rootId":"8284892","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Now
+        What?","releaseYear":2010,"releaseDate":"2010-09-20","origAirDate":"2010-09-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and Cuddy explore the ramifications of their feelings for each other; a colleague''s
+        illness leaves the hospital without a neurosurgeon on site.","shortDescription":"House
+        and Cuddy explore the ramifications of their feelings for each other.","episodeNum":1,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H42M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590224","rootId":"8291809","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Selfish","releaseYear":2010,"releaseDate":"2010-09-27","origAirDate":"2010-09-27","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        seemingly healthy 14-year-old collapses during a skateboarding exhibition;
+        House and Cuddy face the challenge of handling their romantic relationship
+        at work.","shortDescription":"A seemingly healthy 14-year-old collapses during
+        a skateboarding exhibition.","episodeNum":2,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590225","rootId":"8306277","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Unwritten","releaseYear":2010,"releaseDate":"2010-10-04","origAirDate":"2010-10-04","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        popular children''s author has a seizure moments before attempting suicide;
+        House and Cuddy go on a date with Wilson and his girlfriend (Cynthia Watros).","shortDescription":"A
+        popular children''s author has a seizure moments before attempting suicide.","episodeNum":3,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590226","rootId":"8317788","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Massage
+        Therapy","releaseYear":2010,"releaseDate":"2010-10-11","origAirDate":"2010-10-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and his team make unexpected discoveries about a female patient admitted to
+        the hospital after severe and uncontrollable vomiting; House and Cuddy are
+        forced to face the reservations in their relationship after a visit from a
+        massage therapist.","shortDescription":"House and his team make unexpected
+        discoveries about a female patient admitted to the hospital.","episodeNum":4,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590227","rootId":"8327760","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Unplanned
+        Parenthood","releaseYear":2010,"releaseDate":"2010-10-18","origAirDate":"2010-10-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        newborn experiences breathing problems and liver failure; House requests a
+        female doctor be hired for the team; Cuddy asks House to baby-sit.","shortDescription":"A
+        newborn experiences breathing problems and liver failure; Cuddy asks House
+        to baby-sit.","episodeNum":5,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590228","rootId":"8362680","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Office
+        Politics","releaseYear":2010,"releaseDate":"2010-11-06","origAirDate":"2010-11-08","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        chooses a third-year medical student (Amber Tamblyn) when Cuddy forces him
+        to hire a female team member; a politician''s campaign manager mysteriously
+        falls ill with liver failure and temporary paralysis.","shortDescription":"House
+        chooses a third-year medical student when Cuddy forces him to hire a female
+        team member.","episodeNum":6,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Canadian Parental Rating","code":"PG"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590229","rootId":"8364004","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"A
+        Pox on Our House","releaseYear":2010,"releaseDate":"2010-11-15","origAirDate":"2010-11-15","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a 200-year-old medicine jar shatters in a teenager''s palm, she is admitted
+        to the hospital with symptoms closely linked to smallpox; House must make
+        a dangerous decision that puts his life in jeopardy; Wilson and Sam comfort
+        a young patient.","shortDescription":"A teenager is admitted to the hospital
+        with symptoms closely linked to smallpox.","episodeNum":7,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tucker Gates"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590230","rootId":"8364053","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Small
+        Sacrifices","releaseYear":2010,"releaseDate":"2010-11-22","origAirDate":"2010-11-22","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        man becomes a patient after re-enacting the Crucifixion; Taub questions his
+        wife about her relationship with a member of an infidelity support group;
+        Wilson''s relationship with Sam takes an unexpected turn at a co-worker''s
+        wedding.","shortDescription":"A man becomes a patient after re-enacting the
+        Crucifixion; Dr. Taub questions his wife.","episodeNum":8,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590231","rootId":"8473417","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Larger
+        Than Life","releaseYear":2011,"releaseDate":"2011-01-17","origAirDate":"2011-01-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        saving a stranger who fell onto subway tracks, a man suddenly collapses despite
+        appearing to be unscathed; House tries to avoid a dinner with Cuddy and her
+        opinionated mother (Candice Bergen).","shortDescription":"After saving a stranger
+        who fell onto subway tracks, a man collapses despite appearing unscathed.","episodeNum":9,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590232","rootId":"8492313","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Carrot
+        or Stick","releaseYear":2011,"releaseDate":"2011-01-24","origAirDate":"2011-01-24","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        boot-camp trainee and his drill sergeant exhibit the same peculiar symptoms;
+        an indecent photo of Chase is posted online; House helps prepare Rachel for
+        enrollment at a prestigious preschool.","shortDescription":"A boot-camp trainee
+        and his drill sergeant exhibit the same peculiar symptoms.","episodeNum":10,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590234","rootId":"8511393","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Family
+        Practice","releaseYear":2011,"releaseDate":"2011-02-07","origAirDate":"2011-02-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        Cuddy''s mother (Candice Bergen) complains of unusual symptoms, she is admitted
+        to the hospital; Masters questions her principles.","shortDescription":"After
+        Cuddy''s mother complains of unusual symptoms, she is admitted to the hospital.","episodeNum":11,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590233","rootId":"8503083","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"You
+        Must Remember This","releaseYear":2011,"releaseDate":"2011-02-14","origAirDate":"2011-02-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        woman with an extraordinary memory experiences temporary paralysis, and a
+        visit from her sister triggers more health complications; Foreman helps Taub
+        prepare for an exam; House discovers Wilson''s new secret companion.","shortDescription":"A
+        woman with an extraordinary memory experiences temporary paralysis.","episodeNum":12,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Platt"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590235","rootId":"8520448","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Two
+        Stories","releaseYear":2011,"releaseDate":"2011-02-21","origAirDate":"2011-02-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        shares explicit medical stories with students at a school''s career day; two
+        fifth-graders try to help House understand how his antics prevent him from
+        showing Cuddy how he feels.","shortDescription":"House shares explicit medical
+        stories with students at a school''s career day.","episodeNum":13,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590236","rootId":"8520551","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Recession
+        Proof","releaseYear":2011,"releaseDate":"2011-02-28","origAirDate":"2011-02-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        patient has a severe rash after being exposed to caustic chemicals at work;
+        House must choose between attending a charity event to support Cuddy and staying
+        with his patient; Chase and Masters learn about relationships.","shortDescription":"A
+        patient has a severe rash after being exposed to caustic chemicals at work.","episodeNum":14,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["S.J. Clarkson"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590237","rootId":"8542303","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Bombshells","releaseYear":2011,"releaseDate":"2011-03-07","origAirDate":"2011-03-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Cuddy
+        receives news that forces her to re-evaluate her priorities; a teenage patient''s
+        suspicious body scars suggest his illness is more than physical.","shortDescription":"A
+        teenage patient''s suspicious body scars suggest his illness is more than
+        physical.","episodeNum":15,"seasonNum":7,"topCast":["Hugh Laurie","Lisa Edelstein","Robert
+        Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA Parental
+        Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590238","rootId":"8551448","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Out
+        of the Chute","releaseYear":2011,"releaseDate":"2011-03-14","origAirDate":"2011-03-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        professional bull-rider needs risky open-heart surgery after being attacked
+        by the animal; Masters develops a crush on a patient, surprising Taub.","shortDescription":"A
+        professional bull-rider needs risky open-heart surgery; Masters develops a
+        crush on a patient.","episodeNum":16,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590239","rootId":"8565210","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Fall
+        From Grace","releaseYear":2011,"releaseDate":"2011-03-21","origAirDate":"2011-03-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        young homeless man and former drug addict is found in a park with scars and
+        burn marks on his chest; Cuddy expresses her guilt to Wilson.","shortDescription":"A
+        young homeless man and former drug addict is found with scars and burn marks
+        on his chest.","episodeNum":17,"seasonNum":7,"topCast":["Hugh Laurie","Lisa
+        Edelstein","Robert Sean Leonard"],"directors":["Tucker Gates"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590240","rootId":"8594609","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Dig","releaseYear":2011,"releaseDate":"2011-04-11","origAirDate":"2011-04-11","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        learning that Thirteen spent time in prison, House tries to figure out why
+        she was incarcerated; the team makes a discovery about a teacher who has severe
+        respiratory problems.","shortDescription":"House discovers Thirteen spent
+        time in prison; treating a teacher with respiratory problems.","episodeNum":18,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590241","rootId":"8605560","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Last
+        Temptation","releaseYear":2011,"releaseDate":"2011-04-18","origAirDate":"2011-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team;
+        a 16-year-old collapses days before embarking on a sailing tour of the globe.","shortDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team.","episodeNum":19,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tim Southam"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590278","rootId":"8605560","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"La
+        \u00faltima tentaci\u00f3n","releaseYear":2011,"releaseDate":"2011-04-18","origAirDate":"2011-04-18","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team;
+        a 16-year-old collapses days before embarking on a sailing tour of the globe.","shortDescription":"Masters
+        must decide if she wants to be a surgeon or officially join House''s team.","episodeNum":19,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Tim Southam"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590242","rootId":"8637687","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Changes","releaseYear":2011,"releaseDate":"2011-05-02","origAirDate":"2011-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        lottery winner experiences partial paralysis while looking for a long-lost
+        love; medical licenses are jeopardized when Cuddy''s mother (Candice Bergen)
+        threatens to sue the hospital.","shortDescription":"A lottery winner experiences
+        partial paralysis; Cuddy''s mother threatens to sue the hospital.","episodeNum":20,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590277","rootId":"8637687","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Cambios","releaseYear":2011,"releaseDate":"2011-05-02","origAirDate":"2011-05-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        lottery winner experiences partial paralysis while looking for a long-lost
+        love; medical licenses are jeopardized when Cuddy''s mother (Candice Bergen)
+        threatens to sue the hospital.","shortDescription":"A lottery winner experiences
+        partial paralysis; Cuddy''s mother threatens to sue the hospital.","episodeNum":20,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590243","rootId":"8638621","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Fix","releaseYear":2011,"releaseDate":"2011-05-09","origAirDate":"2011-05-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and Wilson disagree on the outcome of a boxing match they bet on; the team
+        suspects House of having another drug problem.","shortDescription":"House
+        and Wilson disagree on the outcome of a boxing match they bet on.","episodeNum":21,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590244","rootId":"8638673","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"After
+        Hours","releaseYear":2011,"releaseDate":"2011-05-16","origAirDate":"2011-05-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Thirteen
+        turns to Chase when a friend comes to her in need of medical attention and
+        can''t be taken to the hospital; House gets devastating news.","shortDescription":"Thirteen
+        turns to Chase for help when a friend comes to her in need of medical attention.","episodeNum":22,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K16"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590245","rootId":"8638724","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Moving
+        On","releaseYear":2011,"releaseDate":"2011-05-23","origAirDate":"2011-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team questions the necessity of the treatments it is giving a performance
+        artist; House''s unexpected action may forever change his relationships with
+        Wilson and Cuddy.","shortDescription":"The team questions the necessity of
+        a performance artist''s treatments; House acts unexpectedly.","episodeNum":23,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590279","rootId":"8638724","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"La
+        vida sigue","releaseYear":2011,"releaseDate":"2011-05-23","origAirDate":"2011-05-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team questions the necessity of the treatments it is giving a performance
+        artist; House''s unexpected action may forever change his relationships with
+        Wilson and Cuddy.","shortDescription":"The team questions the necessity of
+        a performance artist''s treatments; House acts unexpectedly.","episodeNum":23,"seasonNum":7,"topCast":["Hugh
+        Laurie","Lisa Edelstein","Robert Sean Leonard"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8201297_b_v5_ab.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590247","rootId":"8856622","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Twenty
+        Vicodin","releaseYear":2011,"releaseDate":"2011-10-03","origAirDate":"2011-10-03","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        notices strange symptoms in a fellow inmate at the East New Jersey Correctional
+        Facility; a clinic doctor must decide whether to risk her job by helping House.","shortDescription":"House
+        notices strange symptoms in a fellow inmate at the East New Jersey Correctional
+        Facility.","episodeNum":1,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590248","rootId":"8864426","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Transplant","releaseYear":2011,"releaseDate":"2011-10-10","origAirDate":"2011-10-10","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        unexpected visitor offers House the chance to help the Princeton Plainsboro
+        team with a patient; Wilson is unreceptive to House''s attempts to reconnect.","shortDescription":"An
+        unexpected visitor offers House the chance to help the Princeton Plainsboro
+        team with a patient.","episodeNum":2,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Dan Attias"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590249","rootId":"8874808","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Charity
+        Case","releaseYear":2011,"releaseDate":"2011-10-17","origAirDate":"2011-10-17","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a man (Wentworth Miller) collapses after making a generous donation, House
+        and Dr. Chi Park try to identify his medical disorder; Thirteen''s pursuit
+        of happiness is hampered by feelings of guilt.","shortDescription":"When a
+        generous man collapses, House and Dr. Chi Park try to identify his medical
+        disorder.","episodeNum":3,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590250","rootId":"8897519","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Risky
+        Business","releaseYear":2011,"releaseDate":"2011-10-31","origAirDate":"2011-10-31","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        businessman (Michael Nouri) becomes ill days before signing a contract that
+        would relocate his company''s labor force to China; Park prepares for her
+        hearing with the hospital''s disciplinary committee.","shortDescription":"A
+        businessman becomes ill days before signing a contract that relocates his
+        company''s labor force.","episodeNum":4,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590251","rootId":"8898336","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        Confession","releaseYear":2011,"releaseDate":"2011-11-07","origAirDate":"2011-11-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        patient confesses dark secrets to his family and community, compromising his
+        chances of receiving life-saving medical treatment; Chase and Taub rejoin
+        the team; Taub struggles to balance work and fatherhood.","shortDescription":"A
+        patient confesses dark secrets to his community, compromising his chances
+        of survival.","episodeNum":5,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Kate Woods"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590252","rootId":"8898360","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Parents","releaseYear":2011,"releaseDate":"2011-11-14","origAirDate":"2011-11-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team discovers a disturbing family secret while trying to find a bone marrow
+        match for an ailing teen; House tries to remove his ankle monitor so he can
+        go to a boxing match; Taub''s ex-wife wants to move across the country with
+        their daughter.","shortDescription":"The team discovers a disturbing family
+        secret while trying to find a bone marrow match for a teen.","episodeNum":6,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590253","rootId":"8898416","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Dead
+        & Buried","releaseYear":2011,"releaseDate":"2011-11-21","origAirDate":"2011-11-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team discovers its teenage patient isn''t just being dramatic when her symptoms
+        worsen; House becomes consumed with determining the cause of a 4-year-old''s
+        death; Park tries to get Chase to admit why he has become obsessed with grooming.","shortDescription":"The
+        team discovers its teenage patient isn''t just being dramatic when her symptoms
+        worsen.","episodeNum":7,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590254","rootId":"8941367","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Perils
+        of Paranoia","releaseYear":2011,"releaseDate":"2011-11-28","origAirDate":"2011-11-28","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"During
+        an interrogation at the witness stand, a prosecutor has what he thinks is
+        a heart attack; Wilson is determined to prove that House is hiding something;
+        Park starts to come out of her shell.","shortDescription":"During an interrogation,
+        a prosecutor has what he thinks is a heart attack.","episodeNum":8,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590257","rootId":"9029454","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Better
+        Half","releaseYear":2012,"releaseDate":"2012-01-23","origAirDate":"2012-01-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"An
+        Alzheimer''s patient participating in a drug trial suffers from a violent
+        temper; Wilson treats a patient who claims to be in a chaste marriage.","shortDescription":"An
+        Alzheimer''s patient participating in a drug trial suffers from a violent
+        temper.","episodeNum":9,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590258","rootId":"9038453","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Runaways","releaseYear":2012,"releaseDate":"2012-01-30","origAirDate":"2012-01-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        a homeless teenager''s (Bridgit Mendler) symptoms get worse, adult consent
+        is required for an invasive surgery; Taub tries to connect with his daughters;
+        House threatens Foreman''s relationship with a married woman (Yaya DaCosta).","shortDescription":"When
+        a homeless teenager''s symptoms get worse, adult consent is required for an
+        invasive surgery.","episodeNum":10,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Sanford Bookstaver"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590259","rootId":"9053495","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Nobody''s
+        Fault","releaseYear":2012,"releaseDate":"2012-02-06","origAirDate":"2012-02-06","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"Dr.
+        Walter Cofield (Jeffrey Wright), Foreman''s former mentor, places House and
+        the team under review after a violent incident involving a patient.","shortDescription":"House
+        and the team are placed under review after a violent incident involving a
+        patient.","episodeNum":11,"seasonNum":8,"topCast":["Hugh Laurie","Robert Sean
+        Leonard","Omar Epps"],"directors":["Greg Yaitanes"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590260","rootId":"9066285","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Chase","releaseYear":2012,"releaseDate":"2012-02-13","origAirDate":"2012-02-13","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"As
+        Chase treats Moira (Julie Mond), a cloistered nun who is on the verge of making
+        life-altering vows, they form a connection that causes Moira to question her
+        faith; Taub and House take part in a series of pranks.","shortDescription":"As
+        Chase treats Moira, a nun, they form a connection that causes Moira to question
+        her faith.","episodeNum":12,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Matt Shakman"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590261","rootId":"9078572","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Man
+        of the House","releaseYear":2012,"releaseDate":"2012-02-20","origAirDate":"2012-02-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team notices behavioral changes in a marriage counselor who collapsed during
+        a speaking engagement; House and Dominka work to convince Immigration they
+        are a happy couple; House chooses a team leader.","shortDescription":"The
+        team notices behavioral changes in a marriage counselor who collapsed while
+        speaking.","episodeNum":13,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Colin Bucksey"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K7"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590263","rootId":"9093461","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Love
+        Is Blind","releaseYear":2012,"releaseDate":"2012-02-27","origAirDate":"2012-03-19","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team works to save a blind man with a mysterious illness; House''s mother
+        makes an unexpected visit.","shortDescription":"The team works to save a blind
+        man with a mysterious illness; House''s mother visits.","episodeNum":14,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Tim Southam"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590264","rootId":"9094457","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Blowing
+        the Whistle","releaseYear":2012,"releaseDate":"2012-04-02","origAirDate":"2012-04-02","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats an Army veteran who refuses treatment unless he and his brother
+        are given information about their dead father; Adams seeks help when she suspects
+        House is sick.","shortDescription":"A sick Army veteran refuses treatment
+        unless he is given information about his dead father.","episodeNum":15,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Julian Higgins"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Mediakasvatus-
+        ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento de Justi\u00e7a,
+        Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590266","rootId":"9170116","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Gut
+        Check","releaseYear":2012,"releaseDate":"2012-04-09","origAirDate":"2012-04-09","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"After
+        a fight on the ice, a 22-year-old minor league hockey player collapses and
+        coughs up blood; House stuns Wilson; Chase has an offer for Park.","shortDescription":"After
+        a fight on the ice, a 22-year-old minor league hockey player collapses and
+        coughs up blood.","episodeNum":16,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n General de
+        Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590267","rootId":"9181667","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"We
+        Need the Eggs","releaseYear":2012,"releaseDate":"2012-04-16","origAirDate":"2012-04-16","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"House
+        and the team treat a man who sheds tears of blood; when House acts out when
+        his favorite prostitute decides to leave the business.","shortDescription":"The
+        team treats a man who sheds tears of blood; House''s favorite prostitute quits
+        the business.","episodeNum":17,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["David Straiton"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Direcci\u00f3n General
+        de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590268","rootId":"9197169","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Body
+        & Soul","releaseYear":2012,"releaseDate":"2012-04-23","origAirDate":"2012-04-23","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team treats a boy who wakes up from nightmares of being choked still unable
+        to breathe; Park has intimate dreams about co-workers; Dominika discovers
+        a secret that has the potential to ruin her relationship with House.","shortDescription":"The
+        team treats a boy who wakes up from nightmares of being choked still unable
+        to breathe.","episodeNum":18,"seasonNum":8,"topCast":["Hugh Laurie","Robert
+        Sean Leonard","Omar Epps"],"directors":["Stefan Schwartz"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"14+"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"13"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"},{"body":"Direcci\u00f3n General
+        de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590270","rootId":"9209458","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"The
+        C-Word","releaseYear":2012,"releaseDate":"2012-04-30","origAirDate":"2012-04-30","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"When
+        the team treats a 6-year-old with multiple health issues, they must collaborate
+        with her mother (Jessica Collins), who is also a doctor; Wilson and House
+        go on vacation.","shortDescription":"The team treats a 6-year-old with multiple
+        health issues; Wilson and House go on vacation.","episodeNum":19,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Hugh Laurie"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Direcci\u00f3n
+        General de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590271","rootId":"9220724","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Post
+        Mortem","releaseYear":2012,"releaseDate":"2012-05-07","origAirDate":"2012-05-07","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team must convince its patient that a missing House is still calling all the
+        shots.","shortDescription":"The team must convince its patient that a missing
+        House is still calling all the shots.","episodeNum":20,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Peter Weller"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590272","rootId":"9220874","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Holding
+        On","releaseYear":2012,"releaseDate":"2012-05-14","origAirDate":"2012-05-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"The
+        team believes a patient''s problems are both physical and psychological; Foreman
+        tries an alternative approach with House.","shortDescription":"The team believes
+        a patient''s problems are both physical and psychological.","episodeNum":21,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["Miguel Sapochnik"],"ratings":[{"body":"USA
+        Parental Rating","code":"TV14"},{"body":"Canadian Parental Rating","code":"14+"},{"body":"Australian
+        Classification Board","code":"M 15+"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"}],"runTime":"PT00H45M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590273","rootId":"9220882","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Everybody
+        Dies","releaseYear":2012,"releaseDate":"2012-05-21","origAirDate":"2012-05-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"While
+        treating a drug addicted patient, House is forced to look at his own life,
+        future and personal demons.","shortDescription":"While treating a drug addicted
+        patient, House is forced to look at his own life and personal demons.","episodeNum":22,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"directors":["David Shore"],"ratings":[{"body":"USA
+        Parental Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Departamento de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos
+        e Qualifica\u00e7\u00e3o","code":"14"}],"runTime":"PT00H44M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}},{"tmsId":"EP006883590265","rootId":"9159655","seriesId":"185044","subType":"Series","title":"House","episodeTitle":"Swan
+        Song","releaseYear":2012,"releaseDate":"2012-05-21","origAirDate":"2012-05-21","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Drama","Mystery","Medical"],"longDescription":"A
+        special episode looks back at the series so far, including interviews with
+        stars and producers.","shortDescription":"A special episode looks back at
+        the series so far, including interviews with stars and producers.","episodeNum":23,"seasonNum":8,"topCast":["Hugh
+        Laurie","Robert Sean Leonard","Omar Epps"],"ratings":[{"body":"USA Parental
+        Rating","code":"TVPG"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Canadian
+        Parental Rating","code":"PG"},{"body":"Australian Classification Board","code":"M
+        15+"},{"body":"Film & Publication Board","code":"16"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"14"},{"body":"Conseil
+        Sup\u00e9rieur de l''Audiovisuel","code":"-10"}],"preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8729531_b_v5_ac.jpg","category":"Banner-L1","text":"yes","primary":"true","tier":"Season"}}]}'
+  recorded_at: Sun, 27 Sep 2020 20:11:14 GMT
 recorded_with: VCR 6.0.0

--- a/tvsharedb/test/vcr_cassettes/tms_idMV003358300000.yml
+++ b/tvsharedb/test/vcr_cassettes/tms_idMV003358300000.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://data.tmsapi.com/v1.1/programs/MV003358300000?api_key=<TMS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=7200
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 27 Sep 2020 20:13:03 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding,Origin
+      X-Mashery-Responder:
+      - prod-j-worker-us-west-1b-27.mashery.com
+      Content-Length:
+      - '2429'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tmsId":"MV003358300000","rootId":"8329393","subType":"Feature Film","title":"Big
+        Mommas: Like Father, Like Son","releaseYear":2011,"releaseDate":"2011-02-18","titleLang":"en","descriptionLang":"en","entityType":"Movie","genres":["Comedy"],"longDescription":"After
+        stepson Trent (Brandon T. Jackson) witnesses a murder, FBI agent Malcolm Turner
+        (Martin Lawrence) brings back Big Momma, his plus-size alter ego, to help
+        solve the crime. Big Momma goes deep under cover at a girls school of the
+        performing arts, but this time he has Trent and Trent''s female alter ego
+        Charmaine as backup. The duo must try to find the killer before the killer
+        finds them, but complicating matters is Trent''s crush on a student (Jessica
+        Lucas).","shortDescription":"Malcolm Turner and his stepson go under cover
+        at a girls school to find a killer.","cast":[{"billingOrder":"01","role":"Actor","nameId":"990","personId":"990","name":"Martin
+        Lawrence","characterName":"Malcolm Turner/Big Momma"},{"billingOrder":"02","role":"Actor","nameId":"341377","personId":"332503","name":"Brandon
+        T. Jackson","characterName":"Trent/Charmaine"},{"billingOrder":"03","role":"Actor","nameId":"301598","personId":"297676","name":"Jessica
+        Lucas","characterName":"Haley"},{"billingOrder":"04","role":"Actor","nameId":"542007","personId":"522410","name":"Portia
+        Doubleday","characterName":"Jasmine"},{"billingOrder":"05","role":"Actor","nameId":"157886","personId":"157656","name":"Tony
+        Curran","characterName":"Chirkoff"},{"billingOrder":"06","role":"Actor","nameId":"226004","personId":"223403","name":"Ana
+        Ortiz","characterName":"Gail"},{"billingOrder":"07","role":"Actor","nameId":"225461","personId":"222893","name":"Sherri
+        Shepherd","characterName":"Beverly Townsend"},{"billingOrder":"08","role":"Actor","nameId":"344565","personId":"335691","name":"Michelle
+        Ang","characterName":"Mia"},{"billingOrder":"09","role":"Actor","nameId":"504786","personId":"491171","name":"Emily
+        Rios","characterName":"Isabelle"},{"billingOrder":"10","role":"Actor","nameId":"212947","personId":"210745","name":"Henri
+        Lubatti","characterName":"Vlad"},{"billingOrder":"11","role":"Actor","nameId":"596742","personId":"572330","name":"Lorenzo
+        Pisoni","characterName":"Dmitri"},{"billingOrder":"12","role":"Actor","nameId":"291","personId":"291","name":"Max
+        Casella","characterName":"Canetti"},{"billingOrder":"13","role":"Actor","nameId":"95294","personId":"95294","name":"Marc
+        John Jefferies","characterName":"Rembrandt"},{"billingOrder":"14","role":"Actor","nameId":"621422","personId":"597189","name":"Brandon
+        Gill","characterName":"Scratch"},{"billingOrder":"15","role":"Actor","nameId":"633449","personId":"611884","name":"Zack
+        Mines","characterName":"Delant\u00e9"},{"billingOrder":"16","role":"Actor","nameId":"633450","personId":"611885","name":"Trey
+        Lindsey","characterName":"TJ"},{"billingOrder":"17","role":"Actor","nameId":"320070","personId":"313030","name":"Ken
+        Jeong","characterName":"Mailman"}],"crew":[{"billingOrder":"01","role":"Director","nameId":"236145","personId":"232720","name":"John
+        Whitesell"},{"billingOrder":"02","role":"Screenwriter","nameId":"633451","personId":"611886","name":"Matthew
+        Fogel"},{"billingOrder":"03","role":"Producer","nameId":"375714","personId":"366839","name":"David
+        T. Friendly"},{"billingOrder":"04","role":"Producer","nameId":"534228","personId":"517374","name":"Michael
+        Green"},{"billingOrder":"05","role":"Executive Producer","nameId":"303903","personId":"299949","name":"Arnon
+        Milchan"},{"billingOrder":"06","role":"Executive Producer","nameId":"990","personId":"990","name":"Martin
+        Lawrence"},{"billingOrder":"07","role":"Executive Producer","nameId":"754073","personId":"459022","name":"Jeffrey
+        Kwatinetz"},{"billingOrder":"08","role":"Executive Producer","nameId":"428938","personId":"420063","name":"Jeremiah
+        Samuels"},{"billingOrder":"09","role":"Cinematographer","nameId":"468959","personId":"460084","name":"Anthony
+        B. Richmond"},{"billingOrder":"10","role":"Production Design","nameId":"633970","personId":"612444","name":"Meghan
+        C. Rogers"},{"billingOrder":"11","role":"Film Editor","nameId":"472770","personId":"463895","name":"Priscilla
+        Nedd-Friendly"},{"billingOrder":"12","role":"Original Music","nameId":"414221","personId":"405346","name":"David
+        Newman"},{"billingOrder":"13","role":"Costume Designer","nameId":"633971","personId":"612445","name":"Leah
+        Katznelson"},{"billingOrder":"14","role":"Casting","nameId":"528357","personId":"512881","name":"Kim
+        Taylor-Coleman"},{"billingOrder":"15","role":"Casting","nameId":"374327","personId":"365452","name":"Alexa
+        L. Fogel"},{"billingOrder":"16","role":"Art Director","nameId":"917179","personId":"508791","name":"Mark
+        E. Garner"},{"billingOrder":"17","role":"Set Decoration","nameId":"475301","personId":"466426","name":"Frank
+        Galline"}],"directors":["John Whitesell"],"keywords":{"Mood":["Hilarious","Offbeat"],"Time
+        Period":["2010s"],"Theme":["Pursuit","Growing up","Mystery"],"Character":["FBI
+        agent","Grandmother","Stepson","Criminal","Student"],"Setting":["School","United
+        States"],"Subject":["Cross-dressing","Murder case","Father/son relationship","Investigation","Police
+        work","Disguise"]},"officialUrl":"http://www.bigmommashousemovie.com/","qualityRating":{"ratingsBody":"TMS","value":"1.5"},"ratings":[{"body":"Motion
+        Picture Association of America","code":"PG-13"},{"body":"B.C. Film Classification
+        Office","code":"PG"},{"body":"Saskatchewan Film and Video Classification Board","code":"PG"},{"body":"Manitoba
+        Film Classification Board","code":"PG"},{"body":"Alberta''s Film Classification
+        Board","code":"PG"},{"body":"R\u00e9gie du cin\u00e9ma","code":"G"},{"body":"British
+        Board of Film Classification","code":"PG"},{"body":"Maritime Film Classification
+        Board","code":"PG"},{"body":"UK Content Provider","code":"PG"},{"body":"Departamento
+        de Justi\u00e7a, Classifica\u00e7\u00e3o, T\u00edtulos e Qualifica\u00e7\u00e3o","code":"12"},{"body":"Film
+        & Publication Board","code":"13"},{"body":"Mediakasvatus- ja kuvaohjelmayksikk\u00f6","code":"K12"},{"body":"Freiwillige
+        Selbstkontrolle der Filmwirtschaft","code":"6"},{"body":"Direcci\u00f3n General
+        de Radio, Televisi\u00f3n y Cinematograf\u00eda","code":"B"}],"advisories":["Adult
+        Situations","Violence"],"recommendations":[{"tmsId":"MV000379260000","rootId":"15209","title":"Mrs.
+        Doubtfire"},{"tmsId":"MV001719410000","rootId":"160651","title":"Madea''s
+        Family Reunion"},{"tmsId":"MV000468410000","rootId":"18173","title":"The Nutty
+        Professor"}],"runTime":"PT01H48M","preferredImage":{"width":"240","height":"360","uri":"http://wewe.tmsimg.com/assets/p8329393_v_v5_ab.jpg","category":"VOD
+        Art","text":"yes","primary":"true"}}'
+  recorded_at: Sun, 27 Sep 2020 20:13:03 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
- Previously we only saved MV and SH records (movies and series-level show data).
- Now, we also import EP records (individual records)
- When shows are imported, their episodes are imported too