### PR TITLE
Import news when updating show

### DIFF
--- a/tvsharedb/lib/tasks/scheduler.rake
+++ b/tvsharedb/lib/tasks/scheduler.rake
@@ -20,8 +20,9 @@ desc "Update existing shows"
 task update_shows: :environment do
   puts "Updating existing shows..."
 
-  Show.with_tms_id.order(updated_at: :asc).limit(500).find_each do |show|
+  Show.with_tms_id.exclude_episodes.order(updated_at: :asc).limit(500).find_each do |show|
     ImportShowJob.perform_now(tms_id: show.tmsId)
+    ImportShowNewsJob.perform_now(show)
   end
 
   puts "Finished updating existing shows."


### PR DESCRIPTION
- Shows are updated continuously throughout the day.
- We now search for new articles any time a show is updated (in `scheduler.rake` cron job)