### PR TITLE
Import shows via rootId

### DIFF
--- a/tvsharedb/app/jobs/import_show_job.rb
+++ b/tvsharedb/app/jobs/import_show_job.rb
@@ -7,6 +7,7 @@ class ImportShowJob < ApplicationJob
   #
   # options example:
   # { tmsId: 'SH002960010000' } or
+  # { rootId: '1' } or
   # { seriesId: '184483' }
   def perform(options)
     program = HTTParty.get api_url(options)
@@ -65,8 +66,8 @@ class ImportShowJob < ApplicationJob
   private
 
   def api_url(options)
-    if options[:tmsId]
-      "http://data.tmsapi.com/v1.1/programs/#{options[:tmsId]}?api_key=#{ENV['TMS_API_KEY']}&titleLang=en&descriptionLang=en";
+    if options[:tmsId] || options[:rootId]
+      "http://data.tmsapi.com/v1.1/programs/#{options[:tmsId] || options[:rootId]}?api_key=#{ENV['TMS_API_KEY']}&titleLang=en&descriptionLang=en";
     else
       "http://data.tmsapi.com/v1.1/series/#{options[:seriesId]}?api_key=#{ENV['TMS_API_KEY']}&titleLang=en&descriptionLang=en";
     end

--- a/tvsharedb/db/schema.rb
+++ b/tvsharedb/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_182711) do
+ActiveRecord::Schema.define(version: 2020_10_21_205333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_182711) do
     t.string "origAirDate"
     t.string "releaseDate"
     t.integer "releaseYear"
-    t.string "rootId"
+    t.integer "rootId"
     t.string "runTime"
     t.string "seriesId"
     t.text "shortDescription"
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_182711) do
     t.index ["imported_news_at"], name: "index_shows_on_imported_news_at"
     t.index ["original_streaming_network", "original_streaming_network_id"], name: "orignal_network_and_id", unique: true
     t.index ["original_streaming_network"], name: "index_shows_on_original_streaming_network"
+    t.index ["rootId"], name: "index_shows_on_rootId"
     t.index ["tmsId"], name: "index_shows_on_tmsId", unique: true
   end
 


### PR DESCRIPTION
- Convert rootId from string to integer
- Create an index on rootId

The goal of this PR is to enable importing shows via rootId and enable quicker and more accurate numerical sorting based on rootID.