### PR TITLE
Include like counts for followed users in api response

### DIFF
--- a/tvsharedb/app/controllers/comments_controller.rb
+++ b/tvsharedb/app/controllers/comments_controller.rb
@@ -13,7 +13,8 @@ class CommentsController < ApplicationController
       else
         @comments = Comment.includes(:show, :user).where(shows: { tmsId: params[:tmsId] })
       end
-
+      @comment_likes_from_followed_users = @comments.where(comments: { user: @current_user&.followed_users }).group(:id).count
+      @comment_likes_from_followed_users = @comments.joins(:likes).where(likes: { user: @current_user&.followed_users }).group(:id).count
       @current_user_liked_ids = get_current_user_liked_comments(@comments)
       @current_user_reply_comment_ids = get_current_user_reply_comments(@comments)
     end

--- a/tvsharedb/app/controllers/shows/genres_controller.rb
+++ b/tvsharedb/app/controllers/shows/genres_controller.rb
@@ -1,6 +1,6 @@
 class Shows::GenresController < ActionController::Base
   PAGE_SIZE = 25
-  caches_action :index, expires_in: 1.hour, if: -> { Rails.env.production? }
+  caches_action :index, expires_in: 5.minutes, if: -> { Rails.env.production? }
 
   # all genres each with the first PAGE_SIZE shows
   def index

--- a/tvsharedb/app/controllers/shows/news_controller.rb
+++ b/tvsharedb/app/controllers/shows/news_controller.rb
@@ -9,6 +9,8 @@ class Shows::NewsController < ActionController::Base
       @stories = @show.stories.includes(:story_source).order(published_at: :desc).limit(25)
     end
 
+    @stories_likes_from_followed_users = @stories.joins(:likes).where(likes: { user: @current_user&.followed_users }).group(:id).count
+
     render template: 'news/index'
   end
 

--- a/tvsharedb/app/views/comments/_comment.jbuilder
+++ b/tvsharedb/app/views/comments/_comment.jbuilder
@@ -5,6 +5,8 @@ json.shares_count comment.shares_count || 0
 json.created_at_formatted distance_of_time_in_words(comment.created_at, Time.current)
 json.current_user_liked @current_user_liked_ids&.include?(comment.id) || false
 json.current_user_replied @current_user_reply_comment_ids&.include?(comment.id) || false
+json.likes_count_by_followed_users @comment_likes_from_followed_users[comment.id] || 0
+
 
 json.user do
   json.id comment&.user&.id

--- a/tvsharedb/app/views/news/_news.jbuilder
+++ b/tvsharedb/app/views/news/_news.jbuilder
@@ -2,3 +2,5 @@ json.extract! story, :id, :title, :description, :source, :image_url, :published_
 json.likes_count story.likes_count || 0
 json.published_at_formatted distance_of_time_in_words(story.published_at || story.created_at, Time.current)
 json.iframe_enabled story.story_source&.iframe_enabled
+
+json.likes_count_by_followed_users @stories_likes_from_followed_users[story.id] || 0


### PR DESCRIPTION
This data will let the front-end prioritize the order of comments and news stories that have been liked or created by users that the logged in user follows.