### PR TITLE
Implement Sidekiq Queue Priority

### DIFF
--- a/tvsharedb/Procfile
+++ b/tvsharedb/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: RAILS_MAX_THREADS=15 bundle exec sidekiq -c 15
+worker: RAILS_MAX_THREADS=15 bundle exec sidekiq -c 15 -q default -q low_priority

--- a/tvsharedb/app/jobs/import_show_news_from_bing_web_search_job.rb
+++ b/tvsharedb/app/jobs/import_show_news_from_bing_web_search_job.rb
@@ -4,7 +4,7 @@ class ImportShowNewsFromBingWebSearchJob < ApplicationJob
   RESULT_COUNT = 50
   PAGES_TO_SCRAPE = 3
   attr_accessor :show
-  queue_as :default
+  queue_as :low_priority
 
   def perform(show)
     @show = show


### PR DESCRIPTION
Implemented queue priority for background jobs and set the news importer to be low_priority. The news imported takes a long time to run, so this will let quicker jobs run first. 