### PR TITLE
Enable autoindex for stories and shows

### DIFF
--- a/tvsharedb/app/models/show.rb
+++ b/tvsharedb/app/models/show.rb
@@ -2,7 +2,7 @@ class Show < ApplicationRecord
   enum original_streaming_network: { netflix: 0, hulu: 1 }
   include AlgoliaSearch
 
-  algoliasearch enqueue: true, id: :tmsId, if: :has_tms_id?, auto_index: false do
+  algoliasearch enqueue: true, id: :tmsId, if: :has_tms_id? do
     attributes [:title, :episodeTitle, :tmsId, :entityType, :releaseDate,
       :genres, :original_streaming_network, :preferred_image_uri, :cast, :directors,
       :shortDescription, :longDescription, :releaseYear, :seasonNum, :episodeNum]

--- a/tvsharedb/app/models/story.rb
+++ b/tvsharedb/app/models/story.rb
@@ -2,7 +2,7 @@
 class Story < ApplicationRecord
   include AlgoliaSearch
 
-  algoliasearch enqueue: true, auto_index: false do
+  algoliasearch enqueue: true do
     attributes [:title, :short_description, :image_url, :source, :get_source_domain, :show_title]
     searchableAttributes [:title, 'unordered(short_description)', :source, :get_source_domain, :show_title]
     customRanking ['desc(likes_count)', 'desc(shares_count)']


### PR DESCRIPTION
Autoindexing (for searching) is temporarily disabled while we do the initial news importing.

Once the import has finished, merge this PR and run: `Show.reindex && Story.reindex`.

Update: We are no longer using Algolia for searching, so this PR should not be merged at this time.