### PR TITLE
Autodetect zip code

### DIFF
--- a/tvsharedb/Gemfile
+++ b/tvsharedb/Gemfile
@@ -36,6 +36,9 @@ gem 'rack-cors'
 # HTML parsing
 gem 'nokogiri'
 
+# For getting location from IP address
+gem 'geocoder'
+
 # Searching
 gem 'algoliasearch-rails'
 

--- a/tvsharedb/Gemfile.lock
+++ b/tvsharedb/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
+    geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -234,6 +235,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   dotenv-rails
+  geocoder
   httparty
   jbuilder (~> 2.7)
   jwt

--- a/tvsharedb/app/controllers/shows/genres_controller.rb
+++ b/tvsharedb/app/controllers/shows/genres_controller.rb
@@ -38,6 +38,7 @@ class Shows::GenresController < ActionController::Base
     @genre = params[:genre]
     sub_genres = GenreMap.to_h[@genre]
     @shows = Show.with_tms_id.non_episode
+      .select(:id, :title, :genres, :preferred_image_uri, :tmsId, :seriesId, :rootId, :popularity_score)
       .by_genres(sub_genres)
       .order(:popularity_score)
       .yield_self do |show|

--- a/tvsharedb/app/controllers/users_controller.rb
+++ b/tvsharedb/app/controllers/users_controller.rb
@@ -39,6 +39,10 @@ class UsersController < ApplicationController
     @user.destroy
   end
 
+  def location
+    render json: request.location.postal_code
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_user
@@ -51,6 +55,6 @@ class UsersController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def user_params
-      params.permit(:username, :password, :password_digest, :zipcode, :email, :gender, :cable_provider, :birth_date, :image, :bio, :city, :phone_number, :streaming_service)
+      params.permit(:username, :bio, :password, :password_digest, :zipcode, :email, :gender, :cable_provider, :birth_date, :image, :bio, :city, :phone_number, :streaming_service, :name)
     end
 end

--- a/tvsharedb/config/routes.rb
+++ b/tvsharedb/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
   get '/auth/verify', to: 'authentication#verify'
   post '/genres', to: 'shows#stealing_info'
   resources :shares, only: [:create]
+  get '/users/location', to: 'users#location'
   resources :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Creates an api endpoint `users/location` that will estimate a zip code based on the IP address of the request