### PR TITLE
Fix hulu/netflix bug

### DIFF
--- a/tvsharedb/app/controllers/shows/originals_controller.rb
+++ b/tvsharedb/app/controllers/shows/originals_controller.rb
@@ -7,7 +7,7 @@ class Shows::OriginalsController < ApplicationController
 
   # all original shows for a given network (netflix, hulu, etc)
   def show
-    shows = Show.originals.with_tms_id.where(original_streaming_network: params[:network])
+    shows = Show.originals.with_tms_id.where(original_streaming_network: params[:network]&.downcase)
     render json: shows
   end
 end


### PR DESCRIPTION
The bug was caused by unexpected capitalization. This PR "downcases" the incoming "hulu" or "netflix" parameter. 