### PR TITLE
Show Network & Episode Counter

### DIFF
--- a/tvsharedb/app/models/show.rb
+++ b/tvsharedb/app/models/show.rb
@@ -38,6 +38,9 @@ class Show < ApplicationRecord
   validate :is_not_paid_programming
 
   has_many :shares, as: :shareable
+
+  # TODO: Remove show record from appearing in episode relation.
+  has_many :episodes, class_name: 'Show', foreign_key: 'seriesId', primary_key: 'rootId'
   has_one :parent_program, class_name: 'Show', foreign_key: 'rootId', primary_key: 'seriesId'
 
   scope :originals, -> { where.not(original_streaming_network: nil) }
@@ -55,6 +58,10 @@ class Show < ApplicationRecord
   scope :exclude_genre, -> (genre) { where.not("genres @> ARRAY[?]::varchar[]", genre) }
   scope :by_genre, -> (genre) { where("genres @> ARRAY[?]::varchar[]", genre) }
   scope :by_genres, -> (genres) { where("genres && ARRAY[?]::varchar[]", genres) }
+
+  before_update do
+    assign_attributes(networks_count: networks.count, episodes_count: episodes.count)
+  end
 
   def season_and_episode_number
     if episodeNum && seasonNum

--- a/tvsharedb/db/migrate/20201222224528_add_network_and_episode_counter_cache_to_shows.rb
+++ b/tvsharedb/db/migrate/20201222224528_add_network_and_episode_counter_cache_to_shows.rb
@@ -1,0 +1,9 @@
+class AddNetworkAndEpisodeCounterCacheToShows < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shows, :networks_count, :bigint, default: 0
+    add_column :shows, :episodes_count, :bigint, default: 0
+
+    add_index :shows, :networks_count
+    add_index :shows, :episodes_count
+  end
+end

--- a/tvsharedb/db/schema.rb
+++ b/tvsharedb/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_203435) do
+ActiveRecord::Schema.define(version: 2020_12_22_224528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,8 +216,12 @@ ActiveRecord::Schema.define(version: 2020_12_02_203435) do
     t.integer "popularity_score", default: 0
     t.integer "awards_count", default: 0
     t.string "imdb_id"
+    t.bigint "networks_count", default: 0
+    t.bigint "episodes_count", default: 0
+    t.index ["episodes_count"], name: "index_shows_on_episodes_count"
     t.index ["genres"], name: "index_shows_on_genres"
     t.index ["imported_news_at"], name: "index_shows_on_imported_news_at"
+    t.index ["networks_count"], name: "index_shows_on_networks_count"
     t.index ["original_streaming_network", "original_streaming_network_id"], name: "orignal_network_and_id", unique: true
     t.index ["original_streaming_network"], name: "index_shows_on_original_streaming_network"
     t.index ["popularity_score"], name: "index_shows_on_popularity_score"


### PR DESCRIPTION
Cache the network and episode count on the Show model. This will be used primarily for prioritizing manual show -> network matching.

Eventually, this could be optimized: Record the episode count when importing shows, and get rid of the `before_save` callback and only update network count when networks are added/removed.