### PR TITLE
Cache Genres in Background

### DIFF
--- a/tvsharedb/app/controllers/shows/genres_controller.rb
+++ b/tvsharedb/app/controllers/shows/genres_controller.rb
@@ -11,53 +11,11 @@ class Shows::GenresController < ActionController::Base
 
   # all genres each with the first PAGE_SIZE shows
   def index
-    # only show a show once per genre
-    used_tms_ids = Set.new
-    @station_id = params[:station_id]
-    @genre_shows = GenreMap.to_h.reduce({}) do |memo, (title, subgenres)|
-      shows = Show.parent_shows
-        .where.not(tmsId: used_tms_ids)
-        .select(:id, :title, :genres, :preferred_image_uri, :tmsId, :seriesId, :rootId, :popularity_score)
-        .by_genres(subgenres)
-        .order(popularity_score: :desc)
-        .yield_self do |show|
-          if params[:station_id].blank?
-            show.joins(:networks)
-          elsif params[:station_id].to_i.zero? # string, not an integer
-            show.where(original_streaming_network: params[:station_id]&.downcase)
-          else
-            show.joins(:networks).where(networks: { station_id: params[:station_id] })
-          end
-        end
-        .distinct
-        .page(1)
-        .per(PAGE_SIZE)
-
-        shows.each { |show| used_tms_ids.add(show.tmsId) }
-        memo[title] = shows
-      memo
-    end
+    render json: GenreCache.fetch(page: params[:page] || 1, station_id: params[:station_id]), as: :text
   end
 
   def show
-    @station_id = params[:station_id]
-    @genre = params[:genre]
-    sub_genres = GenreMap.to_h[@genre]
-    @shows = Show.parent_shows.select(:id, :title, :genres, :preferred_image_uri, :tmsId, :seriesId, :rootId, :popularity_score)
-      .by_genres(sub_genres)
-      .order(popularity_score: :desc)
-      .yield_self do |show|
-        if params[:station_id].blank?
-          show.parent_shows.joins(:networks)
-        elsif params[:station_id].to_i.zero? # string, not an integer
-          show.non_episode.where(original_streaming_network: params[:station_id])
-        else
-          show.parent_shows.joins(:networks).where(networks: { station_id: params[:station_id] })
-        end
-      end
-      .distinct
-      .page(params[:page])
-      .per(PAGE_SIZE)
+    render json: GenreCache.fetch_genre(page: params[:page] || 1, station_id: params[:station_id], genre: params[:genre]), as: :text
   end
 
   ## This will return a list of stations

--- a/tvsharedb/app/models/network.rb
+++ b/tvsharedb/app/models/network.rb
@@ -1,3 +1,4 @@
 class Network < ApplicationRecord
   has_and_belongs_to_many :shows
+  scope :active, -> { Network.where.not(display_name: nil).where.not(station_id: nil) }
 end

--- a/tvsharedb/lib/genre_cache.rb
+++ b/tvsharedb/lib/genre_cache.rb
@@ -1,0 +1,123 @@
+class GenreCache
+  include Rails.application.routes.url_helpers
+  PAGE_SIZE = 25
+
+  def initialize
+    @used_tms_ids = Set.new
+  end
+
+  def self.cache_all(clear_cache: false)
+    # Cache genre-overview (all-network)
+    self.fetch(station_id: nil, clear_cache: clear_cache)
+
+    # Caching for networks and online streaming networks
+    station_ids = Network.active.pluck(:station_id) + Show.original_streaming_networks.keys
+    station_ids.each do |station_id|
+      # Cache the genre overview
+      self.fetch(station_id: station_id, clear_cache: clear_cache)
+
+      # Cache each genre and all pages
+      self.cache_network_genres(station_id: station_id, clear_cache: clear_cache)
+    end
+  end
+
+  # Cache all pages for all genres for a given network
+  def self.cache_network_genres(station_id:, clear_cache: false)
+    genres = GenreMap.to_h
+
+    genres.to_h.keys.each do |genre|
+      page = 1
+      total_page = 0
+      begin
+        json_string = GenreCache.fetch_genre(page: page, station_id: station_id, genre: genre, clear_cache: clear_cache)
+        json = JSON.parse(json_string)
+        page += 1
+        total_pages =  json.dig('pagination', 'total_pages')
+      end while page < total_pages&.to_i
+    end
+  end
+
+  def self.fetch(page: 1, station_id: nil, clear_cache: false)
+    Rails.cache.fetch("genres_station_#{station_id}_page_#{page}", force: clear_cache) do
+      GenreCache.new.all_genres(page: page, station_id: station_id).to_json
+    end
+  end
+
+  def self.fetch_genre(page:, station_id:, genre:, clear_cache: false)
+    cache_key = "genre_#{genre.downcase.gsub(' ', '_')}_station_#{station_id}_page_#{page}"
+    Rails.cache.fetch(cache_key, force: clear_cache) do
+      GenreCache.new.genre(page: page, station_id: station_id, genre: genre).to_json
+    end
+  end
+
+
+  def self.fetch_network(page: 1, station_id: nil, clear_cache: false)
+    Rails.cache.fetch("genres_station_#{station_id}_page_#{page}", force: clear_cache) do
+      GenreCache.new.all_genres(page: page, station_id: station_id).to_json
+    end
+  end
+
+  def all_genres(page: 1, station_id: nil)
+    GenreMap.to_h.reduce({}) do |memo, (title, sub_genres)|
+      shows = Show.parent_shows
+        .where.not(tmsId: @used_tms_ids)
+        .select(:id, :title, :genres, :preferred_image_uri, :tmsId, :seriesId, :rootId, :popularity_score)
+        .by_genres(sub_genres)
+        .order(popularity_score: :desc, id: :desc)
+        .yield_self do |show|
+          if station_id.blank?
+            show.joins(:networks)
+          elsif station_id.to_i.zero? # string, not an integer
+            show.where(original_streaming_network: station_id&.downcase)
+          else
+            show.joins(:networks).where(networks: { station_id: station_id })
+          end
+        end
+        .distinct
+        .page(page)
+        .per(PAGE_SIZE)
+        shows.each { |show| @used_tms_ids.add(show.tmsId) }
+
+        memo[title] = {
+          results: shows,
+          pagination: {
+            total_count: shows.total_count,
+            next_page: (genre_shows_genres_path(title, page: 2, station_id: station_id) unless shows.last_page?)
+          }
+        }
+      memo
+    end
+  end
+
+  def genre(page: 1, station_id: nil, genre: nil)
+    sub_genres = GenreMap.to_h[genre]
+    shows = Show.parent_shows
+      .select(:id, :title, :genres, :preferred_image_uri, :tmsId, :seriesId, :rootId, :popularity_score)
+      .by_genres(sub_genres)
+      .order(popularity_score: :desc, id: :desc)
+      .yield_self do |show|
+        if station_id.blank?
+          show.joins(:networks)
+        elsif station_id.to_i.zero? # string, not an integer
+          show.where(original_streaming_network: station_id&.downcase)
+        else
+          show.joins(:networks).where(networks: { station_id: station_id })
+        end
+      end
+      .distinct
+      .page(page)
+      .per(PAGE_SIZE)
+
+      {
+        genre: genre,
+        results: shows,
+        pagination: {
+          total_count: shows.total_count,
+          current_page: shows.current_page,
+          total_pages: shows.total_pages,
+          page_size: shows.limit_value,
+          next_page: (genre_shows_genres_path(genre, page: page.to_i + 1, station_id: station_id) unless shows.last_page?)
+        }
+      }
+    end
+  end

--- a/tvsharedb/lib/tasks/scheduler.rake
+++ b/tvsharedb/lib/tasks/scheduler.rake
@@ -1,3 +1,10 @@
+desc "Refresh genre cache"
+task refresh_genre_cache: :environment do
+  puts "Refreshing genre cache..."
+  GenreCache.cache_all(clear_cache: true)
+  puts "Finished refreshing genre cache."
+end
+
 desc "Import new shows via Gracenote live guide"
 task import_shows_via_live_guide: :environment do
   puts "Importing shows via live guide..."
@@ -70,7 +77,7 @@ end
 desc "Import Network Shows"
 task import_network_shows: :environment do
   puts "Importing network shows..."
-  Network.find_each { |network| ImportNetworkShowsJob.perform_later(network) } if Time.now.day.even?
+  Network.active.find_each { |network| ImportNetworkShowsJob.perform_later(network) } if Time.now.day.even?
   puts "Finished importing network shows."
 end
 

--- a/tvsharedb/test/controllers/shows/genres_controller_test.rb
+++ b/tvsharedb/test/controllers/shows/genres_controller_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class Shows::GenresControllerTest < ActionDispatch::IntegrationTest
+
+  test "GET index" do
+    get shows_genres_url
+    assert_response :success
+
+    assert_equal ["Action & Hero Stuff",
+      "Adventure Stuff",
+      "Cartoon & Animated Stuff",
+      "Cooking, Dressing & Decorating",
+      "Cops & Lawyers Stuff",
+      "Cowboy Stuff",
+      "Cultured Stuff",
+      "Earth Stuff",
+      "Entertainment",
+      "Funny Stuff",
+      "Game Shows",
+      "Guilty Pleasure",
+      "Love Stuff",
+      "People Talking",
+      "Potentially Dramatic",
+      "Scary Stuff",
+      "Sci-Fi Stuff",
+      "Smart Stuff",
+      "Soap Opera Stuff",
+      "Sports Stuff"
+    ], response.parsed_body.keys
+
+    assert_equal ['results', 'pagination'], response.parsed_body["Action & Hero Stuff"].keys
+    assert_equal ['total_count', 'next_page'], response.parsed_body["Action & Hero Stuff"]['pagination'].keys
+  end
+
+  test "GET show" do
+    genre = 'Action & Hero Stuff'
+    get genre_shows_genres_url(genre: genre)
+    assert_response :success
+
+    assert_equal genre, response.parsed_body['genre']
+    assert_equal ["genre", "results", "pagination"], response.parsed_body.keys
+    assert_equal ["total_count", "current_page", "total_pages", "page_size", "next_page"], response.parsed_body['pagination'].keys
+  end
+end


### PR DESCRIPTION
Previously, we calculated all of the genre logic when the page was requested and then we cached that for a few hours.

The problem was it took to long to render that initial page. Resulted in timeouts and a confusing a poor user experience.

With this PR we cache all that genre logic behind the scenes, so that every genre page request is served quickly from the cache.

The cache is updated once a day via `GenreCache.cache_all(clear_cache: true)`