### PR TITLE
Allow for periods in username

### DIFF
--- a/tvsharedb/config/routes.rb
+++ b/tvsharedb/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
   resources :shares, only: [:create]
   get '/users/location', to: 'users#location'
 
-  resources :users, only: [:show, :update, :create], param: :username do
+  resources :users, only: [:show, :update, :create], param: :username, username: /[^\/]+/ do
     get :reactions
     get :favorites
     get :followers


### PR DESCRIPTION
The router was interpreting "user.name" as the path "user" and format "name".

This commit adds a regex constraint to the route :key that will allow for periods and other characters.