### PR TITLE
Return error message if social login is unsuccessful

### DIFF
--- a/tvsharedb/app/controllers/authentication_controller.rb
+++ b/tvsharedb/app/controllers/authentication_controller.rb
@@ -49,8 +49,9 @@ class AuthenticationController < ApplicationController
       token = encode(user_id: @user.id, username: @user.username)
       render json: { token: token , user: @user}, status: :ok
     else
-      Rails.logger.warn "Social login/signup unsuccessful: #{@user.errors.full_messages.to_sentence}"
-      render json: { error: 'unauthorized' }, status: :unauthorized
+      error_message = @user.errors.full_messages.to_sentence
+      Rails.logger.warn "Social login/signup unsuccessful: #{error_message}"
+      render json: { error: error_message }, status: :unauthorized
     end
   end
 

--- a/tvsharedb/test/controllers/authentication_controller_test.rb
+++ b/tvsharedb/test/controllers/authentication_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AuthenticationControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = User.create(email: 'example@example.com',
+    @user = User.create(email: 'test@example.com',
       username: 'example', password: 'password')
   end
 
@@ -12,7 +12,6 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
       password: 'password'
     }
     post auth_login_path, params: params, as: :json
-
     assert :success
     assert json_response.has_key?('token')
     refute json_response.has_key?('error')
@@ -42,4 +41,16 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     assert :unauthorized
   end
 
+  test 'user gets error message when creating an account with social login but email has been taken' do
+    social_params = {
+      sub: '123',
+      email: @user.email
+    }.as_json
+
+    GoogleAuthVerification.stubs(:verify).returns(social_params)
+    post auth_login_social_url, params: { google_token: '123' }
+
+    assert_response :unauthorized
+    assert_equal 'Email has already been taken', response.parsed_body['error']
+  end
 end


### PR DESCRIPTION
```json
 { "error": "username has been taken" }
 ```