### PR TITLE
Generate a unique username if derived social username is taken

### DIFF
--- a/tvsharedb/app/controllers/authentication_controller.rb
+++ b/tvsharedb/app/controllers/authentication_controller.rb
@@ -47,7 +47,7 @@ class AuthenticationController < ApplicationController
       unless @user.persisted?
         @user.email = social_data.dig('email')
         @user.image = social_data.dig('picture')
-        @user.username = social_data.dig('email')&.split('@')&.first
+        @user.username = User.get_unique_username(social_data.dig('email')&.split('@')&.first)
         @user.password = SecureRandom.alphanumeric(64) # random password
         @user.save
       end
@@ -72,7 +72,7 @@ class AuthenticationController < ApplicationController
       unless @user.persisted?
         @user.email = social_data.dig('email')
         @user.image = social_data.dig('picture', 'data', 'url')
-        @user.username = social_data.dig('email')&.split('@')&.first
+        @user.username = User.get_unique_username(social_data.dig('email')&.split('@')&.first)
         @user.password = SecureRandom.alphanumeric(64) # random password
         @user.save
       end

--- a/tvsharedb/app/models/user.rb
+++ b/tvsharedb/app/models/user.rb
@@ -35,6 +35,16 @@ class User < ApplicationRecord
     user.save!
   end
 
+  # For social logins we base their username off of their email
+  # If the username is already taken, append a random string
+  def self.get_unique_username(string)
+    if User.where(username: string).exists?
+      string = User.get_unique_username("#{string}#{rand(1..999)}")
+    end
+
+    string
+  end
+
   private
 
   def password_complexity

--- a/tvsharedb/test/controllers/authentication_controller_test.rb
+++ b/tvsharedb/test/controllers/authentication_controller_test.rb
@@ -106,7 +106,7 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     facebook_token = 'fbtoken'
     social_data = {
       id: facebook_id,
-      email: 'facebook_auth@example.com',
+      email: 'example@example1.com',
     }.as_json
 
     @user.update(facebook_id: facebook_id, email: 'auth@example.com')
@@ -202,5 +202,24 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     post auth_login_path, params: params, as: :json
 
     assert_equal 'It looks like you have already created a TV Talk account with Facebook. Please return to the login page and sign in with Facebook.', response.parsed_body['error']
+  end
+
+  test 'when a user signs up via social login but their derived username exists' do
+    social_params = {
+      sub: '123',
+      email: "#{@user.username}@social.com"
+    }.as_json
+    GoogleAuthVerification.stubs(:verify).returns(social_params)
+
+    assert_difference -> { User.count }, 1 do
+      post auth_login_social_url, params: { google_token: '123' }
+    end
+
+    assert response.parsed_body.has_key?('token')
+    assert response.parsed_body['user'].has_key?('id')
+    assert response.parsed_body['user'].has_key?('username')
+    assert_not_equal @user.username, response.parsed_body['user']['username']
+    assert_equal "#{@user.username}@social.com", response.parsed_body['user']['email']
+    refute response.parsed_body.has_key?('error')
   end
 end

--- a/tvsharedb/test/models/user_test.rb
+++ b/tvsharedb/test/models/user_test.rb
@@ -111,4 +111,13 @@ class UserTest < ActiveSupport::TestCase
     refute user.save
     assert user.errors[:username].present?
   end
+
+  test '.get_unique_username' do
+    string = 'user'
+    User.create(username: string, password: '123456', email: 'test@test.com')
+
+    unique_username = User.get_unique_username(string)
+    assert unique_username.present?
+    assert_not_equal string, unique_username
+  end
 end


### PR DESCRIPTION
When a user signs up via facebook or google we auto-generate their username based on the social account's email address.

So `example@test.com` will turn into the username `example`.

This PR ensures that if an unrelated account already had the username `example` then the autogenerated username would turn into something like `example333`.

However this does not apply to traditional username or email signup process. In that process, if their chosen username is taken, an error message will tell prompt them to choose a new one.