### PR TITLE
Added created_at to notifications response

### DIFF
--- a/tvsharedb/README-API.md
+++ b/tvsharedb/README-API.md
@@ -662,6 +662,7 @@ Returns all notifications belonging to the logged in user.
 		"message": "ThaRock liked your comment",
 		"notifiable_type": "Comment",
 		"notifiable_id": 298486374,
+		"created_at": "2021-02-21T17:13:04.792Z",
 		"read_at": "",
 		"actor": {
 			"username": "ThaRock",
@@ -708,6 +709,7 @@ Returns unread notifications belonging to the logged in user.
 		"message": "ThaRock liked your comment",
 		"notifiable_type": "Comment",
 		"notifiable_id": 298486374,
+    "created_at": "2021-02-21T17:13:04.792Z",
 		"read_at": "",
 		"actor": {
 			"username": "ThaRock",

--- a/tvsharedb/app/views/notifications/_notification.jbuilder
+++ b/tvsharedb/app/views/notifications/_notification.jbuilder
@@ -1,4 +1,4 @@
-json.extract! notification, :id, :message, :notifiable_type, :notifiable_id, :read_at
+json.extract! notification, :id, :message, :notifiable_type, :notifiable_id, :created_at, :read_at
 json.actor do
   json.username notification&.actor&.username
   json.image notification&.actor&.image

--- a/tvsharedb/test/controllers/notifications_controller_test.rb
+++ b/tvsharedb/test/controllers/notifications_controller_test.rb
@@ -17,6 +17,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     results = response.parsed_body['results']
     notification = results.find { |result| result['id'] == @unread_notification.id }
     assert_equal @unread_notification.message, notification['message']
+    assert_equal @unread_notification.created_at.to_datetime.to_s, notification['created_at'].to_datetime.to_s
     assert_equal @unread_notification.read_at, notification['read_at']
     assert_equal @unread_notification.actor.username, notification['actor']['username']
     assert_equal @unread_notification.actor.image, notification['actor']['image']


### PR DESCRIPTION

### `GET` `/notifications`
Returns all notifications belonging to the logged in user.

##### Response:

```json
{
	"pagination": {
		"current_page": 1,
		"total_pages": 1,
		"prev_page": "",
		"next_page": "",
		"total_count": 2,
		"current_per_page": 50
	},
	"results": [{
		"id": 893151879,
		"message": "ThaRock liked your comment",
		"notifiable_type": "Comment",
		"notifiable_id": 298486374,
		"created_at": "2021-02-21T17:13:04.792Z",
		"read_at": "",
		"actor": {
			"username": "ThaRock",
			"image": "http://example.com/img.jpg",
			"bio": "A bio"
		}
	}]
}
```