### PR TITLE
Fix admin/users login type data

### DIFF
--- a/tvsharedb/app/views/admin/users/index.jbuilder
+++ b/tvsharedb/app/views/admin/users/index.jbuilder
@@ -2,5 +2,5 @@ json.partial! partial: 'shared/pagination', records: @users
 
 json.results(@users) do |user|
   json.extract! user, :id, :username, :email, :zipcode, :created_at, 
-    :image, :bio, :city, :phone_number, :streaming_service, :likes_count, :comments_count
+    :image, :bio, :city, :phone_number, :streaming_service, :likes_count, :comments_count, :login_type
 end


### PR DESCRIPTION
https://tvchat-api.herokuapp.com/admin/users

Fixed a small bug that was causing all user login sources to be marked as email (rather than apple, google, fb, etc).

Before | After
--- | ---
<img width="139" alt="Screen Shot 2021-12-11 at 5 24 18 PM" src="https://user-images.githubusercontent.com/742111/145693458-e8a5d2be-a631-4107-9066-38215aff7d3c.png"> | <img width="141" alt="Screen Shot 2021-12-11 at 5 24 41 PM" src="https://user-images.githubusercontent.com/742111/145693457-91533f15-7fff-4bc0-b5be-b6fda1efde1b.png">