### PR TITLE
Assign Multiple Networks

### DIFF
--- a/tvsharedb/app/controllers/admin/matching/networks_controller.rb
+++ b/tvsharedb/app/controllers/admin/matching/networks_controller.rb
@@ -29,7 +29,9 @@ class  Admin::Matching::NetworksController < Admin::MatchingController
       head(:not_acceptable)
     end
 
-    Show.assign_network(show_params, params[:networkId]) if params[:networkId]
+    params[:networkIds].each do |network_id|
+      Show.assign_network(show_params, network_id)
+    end
 
     if params[:tmsId]
       @show = Show.find_by(tmsId: params[:tmsId])

--- a/tvsharedb/app/controllers/admin/matching_controller.rb
+++ b/tvsharedb/app/controllers/admin/matching_controller.rb
@@ -28,7 +28,7 @@ class Admin::MatchingController < AdminController
   end
 
   def shows
-    data = Show.originals.order(:title)
+    data = Show.originals.non_episode.order(:title)
     render json: data
   end
 

--- a/tvsharedb/app/javascript/components/admin/matcher/Importer.js
+++ b/tvsharedb/app/javascript/components/admin/matcher/Importer.js
@@ -8,7 +8,7 @@ class Importer extends React.Component {
     filterText: '',
     searchResults: [],
     dbShow: null,
-    selectedNetwork: null,
+    selectedNetworks: null,
     isLoading: true
   }
 
@@ -34,15 +34,17 @@ class Importer extends React.Component {
   }
 
   onClickSaveMatch = (show) => {
-    const {selectedNetwork} = this.state;
+    const {selectedNetworks} = this.state;
     const {seriesId, tmsId} = show;
-    const networkId = selectedNetwork.value;
+    const networkIds = selectedNetworks?.map((network) => {
+      return network.value;
+    });
     this.setState({isLoading: true})
     const url = '/admin/matching/networks/match'
     const data = {
       seriesId,
-      networkId,
-      tmsId
+      tmsId,
+      networkIds
     }
     fetch(url, {
       method: 'PUT',
@@ -57,7 +59,7 @@ class Importer extends React.Component {
   }
 
   onSelect = (selected) => {
-    this.setState({selectedNetwork: selected })
+    this.setState({selectedNetworks: selected })
   }
 
   getShowFromDb = (tmsId) => {
@@ -202,8 +204,11 @@ class Importer extends React.Component {
 
     const ShowContainer = () => {
       const {networks} = this.props;
-      const {selectedShow, dbShow, isLoading, selectedNetwork} = this.state;
+      const {selectedShow, dbShow, isLoading, selectedNetworks} = this.state;
       const options = networks && networks.map((network) => {
+        return { label: network.display_name, value: network.id }
+      })
+      const selectedNetworkIds = dbShow && dbShow.networks.map((network) => {
         return { label: network.display_name, value: network.id }
       })
 
@@ -222,18 +227,20 @@ class Importer extends React.Component {
         )
       }
 
-      if (!isLoading && dbShow && dbShow.id && dbShow.networks.length === 0) {
+      if (!isLoading && dbShow && dbShow.id) {
         return (
           <div>
-            <p>Found in TV Chat's database, but not associated with a network.</p>
+            <p>Found in TV Chat's database</p>
             <h3>TV Chat #{dbShow.id}</h3>
             <p>Display Genres: {dbShow.display_genres?.join(', ')}</p>
             <div key={dbShow.id}>
               <p>Select a network:</p>
               <Select
+                isMulti
                 options={options}
                 onChange={this.onSelect}
-                value={selectedNetwork}
+                value={selectedNetworks || selectedNetworkIds}
+                defaultValue={selectedNetworkIds}
               />
               <button
                 onClick={this.onClickSaveMatch.bind(this, dbShow)}
@@ -244,18 +251,6 @@ class Importer extends React.Component {
           </div>
         )
       }
-
-      if (!isLoading && dbShow && dbShow.id && dbShow.networks.length > 0) {
-        return (
-          <div>
-            <p>Found in TV Chat's database, and associated with a network.</p>
-            <h3>TV Chat #{dbShow.id}</h3>
-            <p>Display Genres: {dbShow.display_genres?.join(', ')}</p>
-            <h3>Network: {dbShow.networks.join(', ')}</h3>
-          </div>
-        )
-      }
-
       return '';
     }
 

--- a/tvsharedb/app/views/admin/matching/show.jbuilder
+++ b/tvsharedb/app/views/admin/matching/show.jbuilder
@@ -1,3 +1,3 @@
 json.merge! @show.attributes
-json.networks @show.networks_and_streaming_services.map(&:display_name)
+json.networks @show.networks_and_streaming_services
 json.display_genres GenreMap.find_display_genres(@show.genres)


### PR DESCRIPTION
<img width="627" alt="Screen Shot 2022-05-08 at 11 57 17 PM" src="https://user-images.githubusercontent.com/742111/167338170-48897b4e-3f84-4419-88e7-437b5bba848e.png">

This PR allows for multiple networks to be assigned (or reassigned) for a show. 

However, a show can only belong to a single streaming service at a time. We can remove that limitation in a later PR.