### PR TITLE
Fix enum values for streaming networks

### DIFF
--- a/tvsharedb/app/models/show.rb
+++ b/tvsharedb/app/models/show.rb
@@ -77,7 +77,7 @@ class Show < ApplicationRecord
     paramount: 5,
     peacock: 6,
     discovery: 7,
-    epix: 7
+    epix: 8
   }
 
   acts_as_votable cacheable_strategy: :update_columns


### PR DESCRIPTION
## Summary
- fix duplicate enum value for `epix`

## Testing
- `bundle exec rake test` *(fails: rbenv: version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b6769421c832b9f773e6fe4203a6f