### PR TITLE
Fix trailing backslash in test file

### DIFF
--- a/tvsharedb/test/lib/get_show_image_test.rb
+++ b/tvsharedb/test/lib/get_show_image_test.rb
@@ -24,4 +24,3 @@ class GetShowImageTest < ActiveSupport::TestCase
     end
   end
 end
-\


### PR DESCRIPTION
## Summary
- cleanup `get_show_image_test.rb` by removing stray backslash

## Testing
- `bundle exec rake test TEST=test/lib/get_show_image_test.rb` *(fails: rbenv version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b73295f78832ba649d9c6ba302a29