### PR TITLE
Fix image category condition in GetShowImage

### DIFF
--- a/tvsharedb/app/lib/get_show_image.rb
+++ b/tvsharedb/app/lib/get_show_image.rb
@@ -60,7 +60,7 @@ class GetShowImage
       image['text'] == 'yes' &&
       image['aspect'] == '4x3' &&
       image['tier'] == 'Series' &&
-      image['category'] == 'Banner-L1' || image['category'] == 'Banner-L1T'
+      (image['category'] == 'Banner-L1' || image['category'] == 'Banner-L1T')
     end
   end
 
@@ -70,7 +70,7 @@ class GetShowImage
       image['text'] == 'yes' &&
       image['aspect'] == '4x3' &&
       image['tier'] == 'Season' &&
-      image['category'] == 'Banner-L1' || image['category'] == 'Banner-L1T'
+      (image['category'] == 'Banner-L1' || image['category'] == 'Banner-L1T')
     end
   end
 


### PR DESCRIPTION
## Summary
- ensure `Banner-L1` or `Banner-L1T` categories require all other conditions in `GetShowImage`

## Testing
- `bin/rails test test/lib/get_show_image_test.rb` *(fails: rbenv: version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b78379bb8832bb92f546a88fb21c1