### PR TITLE
Update top comments view filter

### DIFF
--- a/tvsharedb/db/views/top_comments_v01.sql
+++ b/tvsharedb/db/views/top_comments_v01.sql
@@ -1,1 +1,8 @@
-SELECT id, sum(COALESCE(likes_count,0) + COALESCE(sub_comments_count,0) + COALESCE(shares_count,0)  ) as score FROM "comments" WHERE likes_count > 0 OR sub_comments_count > 0 OR shares_count > 0 AND status = 0 GROUP BY "id" ORDER BY score desc
+SELECT id,
+  COALESCE(likes_count, 0) +
+  COALESCE(sub_comments_count, 0) +
+  COALESCE(shares_count, 0) AS score
+FROM "comments"
+WHERE (likes_count > 0 OR sub_comments_count > 0 OR shares_count > 0)
+  AND status = 0
+ORDER BY score DESC


### PR DESCRIPTION
## Summary
- correct the `top_comments_v01` SQL view to require score-positive comments with status=0

## Testing
- `bundle exec rails test` *(fails: rbenv: version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b7bc2a144832b80b78b2fb53dc213