### PR TITLE
chore: externalize API hostnames

### DIFF
--- a/tvsharedb/README.md
+++ b/tvsharedb/README.md
@@ -9,12 +9,16 @@ Locally these keys should be saved in a `.env` file. That's a file without a nam
 Sample .env file:
 ```
 TMS_API_KEY=abc123
+API_HOST=https://tvchat-api.herokuapp.com
+NEWS_API_HOST=https://tvchat-news-search.herokuapp.com
 ```
 
 Whenever your application loads, these variables will be available in `ENV`:
 
 ```ruby
 ENV['TMS_API_KEY']
+ENV['API_HOST']
+ENV['NEWS_API_HOST']
 ```
 
 In production, we should use [config variables](https://devcenter.heroku.com/articles/config-vars). `heroku config:set TMS_API_KEY=123`.

--- a/tvsharedb/app/jobs/import_show_news_job.rb
+++ b/tvsharedb/app/jobs/import_show_news_job.rb
@@ -47,7 +47,7 @@ class ImportShowNewsJob < ApplicationJob
   end
 
   def news_api_host
-    Rails.env.development? ? "http://localhost:8000" : "https://tvchat-news-search.herokuapp.com"
+    ENV['NEWS_API_HOST'] || (Rails.env.development? ? 'http://localhost:8000' : 'https://tvchat-news-search.herokuapp.com')
   end
 
   #

--- a/tvsharedb/app/views/authentication/apple_test.html.erb
+++ b/tvsharedb/app/views/authentication/apple_test.html.erb
@@ -36,7 +36,7 @@
 
         // construct an HTTP request
         var xhr = new XMLHttpRequest();
-        xhr.open("POST", "https://tvchat-api.herokuapp.com/auth/apple", true);
+        xhr.open("POST", "<%= (ENV['API_HOST'] || 'https://tvchat-api.herokuapp.com') %>/auth/apple", true);
         xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
 
         // send the collected data as JSON

--- a/tvsharedb/env.example
+++ b/tvsharedb/env.example
@@ -4,3 +4,5 @@ CLOUDINARY_URL=''
 GOOGLE_AUTH_CLIENT_ID=''
 TMS_API_KEY=''
 FRONT_END_URL=http://localhost:3000
+API_HOST=https://tvchat-api.herokuapp.com
+NEWS_API_HOST=https://tvchat-news-search.herokuapp.com


### PR DESCRIPTION
## Summary
- allow NEWS_API_HOST override in ImportShowNewsJob
- inject API_HOST in Apple auth view
- document API_HOST and NEWS_API_HOST in README and env.example

## Testing
- `bundle exec rake test` *(fails: rbenv version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b7cfba828832b89dcf099b67b8fa4