### PR TITLE
Fix README trailing shell prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ __Setup your database:__ `bundle exec rake db:setup`
 This should create the database, run the migrations, and seed the database with a list of networks.
 
 __Import shows into your database:__
-- Open a rails console: `bundle exec rails console`
-- Start the `ImportLiveGuideJob.perform_now`
+- Open a Rails console:
+  ```bash
+  bundle exec rails console
+  ```
+- Start the job:
+  ```ruby
+  ImportLiveGuideJob.perform_now
+  ```
 - This will start importing shows that are currently airing on TV. Let this run for a couple of minutes and then feel free to stop it (by pressing `ctrl+c`)
 
 You should now have a number of Networks and real shows in your database.


### PR DESCRIPTION
## Summary
- fix trailing text in README
- format setup instructions as code blocks

## Testing
- `tail -c1 README.md | od -An -t u1`

------
https://chatgpt.com/codex/tasks/task_e_683b7df4aa1c832b9a122838aa622b55