### PR TITLE
Add environment variable check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ npm run comment-bot --prefix tvsharedb
 ```
 
 On Heroku, configure the Scheduler add-on to execute the same command each day.
+
+## Environment Variable Check
+
+Before starting the server, you can verify that all required `.env` keys are
+present. The repo includes a helper script:
+
+```bash
+npm run check-env --prefix tvsharedb
+```
+
+If any variables from `tvsharedb/env.example` are missing, the script prints the
+keys and exits with an error code.

--- a/tvsharedb/package.json
+++ b/tvsharedb/package.json
@@ -35,6 +35,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "scripts": {
-    "comment-bot": "node scripts/gracenote-comment-cron.js"
+    "comment-bot": "node scripts/gracenote-comment-cron.js",
+    "check-env": "node scripts/check-env.js"
   }
 }

--- a/tvsharedb/scripts/check-env.js
+++ b/tvsharedb/scripts/check-env.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadRequiredKeys() {
+  const envExamplePath = path.join(__dirname, '..', 'env.example');
+  if (!fs.existsSync(envExamplePath)) {
+    return [];
+  }
+  const content = fs.readFileSync(envExamplePath, 'utf8');
+  return content
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('#'))
+    .map(line => line.split('=')[0]);
+}
+
+function checkEnv(keys) {
+  const missing = keys.filter(key => !process.env[key]);
+  if (missing.length) {
+    console.error('Missing required environment variables:');
+    missing.forEach(key => console.error(`- ${key}`));
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  const required = loadRequiredKeys();
+  checkEnv(required);
+  console.log('All required environment variables are set.');
+}


### PR DESCRIPTION
## Summary
- ensure required .env keys are present at startup
- document how to run the script
- expose `npm run check-env` command

## Testing
- `git status --short`
- `node tvsharedb/scripts/check-env.js` *(fails here because env vars are absent)*

------
https://chatgpt.com/codex/tasks/task_e_683ba8d00e5c832bbce7541b7142a0d2