### PR TITLE
Add GRACENOTE_API_KEY to env and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You should now have a number of Networks and real shows in your database.
 ## GraceNote Comment Bot
 
 This repository includes a Node.js script that posts daily comments using episode metadata from GraceNote.
+Set the `GRACENOTE_API_KEY` environment variable (see `tvsharedb/env.example`) so the script can authenticate with the service.
 
 Run the job locally with:
 

--- a/tvsharedb/env.example
+++ b/tvsharedb/env.example
@@ -3,6 +3,7 @@ BING_API_KEY=
 CLOUDINARY_URL=''
 GOOGLE_AUTH_CLIENT_ID=''
 TMS_API_KEY=''
+GRACENOTE_API_KEY=''
 FRONT_END_URL=http://localhost:3000
 API_HOST=https://tvchat-api.herokuapp.com
 NEWS_API_HOST=https://tvchat-news-search.herokuapp.com


### PR DESCRIPTION
## Summary
- add `GRACENOTE_API_KEY` to example env file
- document required key in the comment bot section of the README

## Testing
- `npm run check-env --prefix tvsharedb`

------
https://chatgpt.com/codex/tasks/task_e_683baba5077c832baeeebef217fd6246