### PR TITLE
Fix UrlApi to use ENV key

### DIFF
--- a/tvsharedb/app/lib/url_api.rb
+++ b/tvsharedb/app/lib/url_api.rb
@@ -1,9 +1,8 @@
 class UrlApi
   include HTTParty
   def self.fetch start_date, end_date, networks
-    api_url = "https://data.tmsapi.com/v1.1/lineups/USA-HULU501-DEFAULT/grid?startDateTime=#{start_date}&endDateTime=#{end_date}&stationId=#{networks.map{|network| network[:stationId]}}&imageAspectTV=4x3&imageSize=Lg&api_key=v5nfdpmz66hp2nd5t9gefcrc"
+    api_url = "https://data.tmsapi.com/v1.1/lineups/USA-HULU501-DEFAULT/grid?startDateTime=#{start_date}&endDateTime=#{end_date}&stationId=#{networks.map{|network| network[:stationId]}}&imageAspectTV=4x3&imageSize=Lg&api_key=#{ENV['TMS_API_KEY']}"
     resp = HTTParty.get(api_url)
-    byebug
-    data = resp.body
+    resp.body
   end
 end


### PR DESCRIPTION
## Summary
- use `ENV['TMS_API_KEY']` for authentication
- remove stray `byebug` and return response body

## Testing
- `bundle exec rake test` *(fails: rbenv: version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683baba13808832b8f9b82c26265ed78