### PR TITLE
Add API key check in LineupCache

### DIFF
--- a/tvsharedb/lib/lineup_cache.rb
+++ b/tvsharedb/lib/lineup_cache.rb
@@ -5,6 +5,8 @@ class LineupCache
   SUPPORTED_TIME_ZONES = ['EST', 'CST', 'MDT', 'AKDT', 'HST', 'PDT']
 
   def initialize(lineup: nil, timezone: 'EST')
+    raise RuntimeError, 'TMS_API_KEY not set' if ENV['TMS_API_KEY'].blank?
+
     @lineup = lineup || get_lineup_by_timezone(timezone)
     @cache_key = "lineup_#{@lineup}"
     @show_map = {}

--- a/tvsharedb/test/lib/lineup_cache_test.rb
+++ b/tvsharedb/test/lib/lineup_cache_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class LineupCacheTest < ActiveSupport::TestCase
+  test 'raises an error when TMS_API_KEY is missing' do
+    original_key = ENV['TMS_API_KEY']
+    ENV['TMS_API_KEY'] = nil
+
+    error = assert_raises RuntimeError do
+      LineupCache.new
+    end
+
+    assert_equal 'TMS_API_KEY not set', error.message
+  ensure
+    ENV['TMS_API_KEY'] = original_key
+  end
+end


### PR DESCRIPTION
## Summary
- raise an error if `TMS_API_KEY` is not set when instantiating `LineupCache`
- test that the error is raised when the key is missing

## Testing
- `bundle exec rake test TEST=test/lib/lineup_cache_test.rb` *(fails: rbenv: version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683bc6be7710832baa81152fa2e72d7a